### PR TITLE
Enoxaparin Bug Fix

### DIFF
--- a/qumi-codes.py
+++ b/qumi-codes.py
@@ -32,13 +32,15 @@ def ndc_eleven_digits(ndc):
 
 # Processes the description to separate out useful information on the unit dosage
 def process_description(desc):
-        pattern = r"(?:.*\/)?\s*(\d+(\.\d+)?)\s*([^\d\(\)]*)\s*in\s*(\d+)\s*([^\d\(\)]*)"
-        match = re.search(pattern, desc)
-        if match:
-            unit_num, _, unit, form_num, form = match.groups()
-            return unit_num.strip(), unit.strip(), form_num.strip(), form.strip()
-        else:
-            return np.nan, np.nan, np.nan, np.nan
+    parts = desc.split('/')
+    last_part = parts[-1]
+    pattern = r"\s*(\d*\.\d+|\d+)\s*([^\d\(\)\s][^\(\)]*?)\s*in\s*(\d+)\s*([^\d\(\)\s][^\(\)]*)"
+    match = re.search(pattern, last_part.strip())
+    if match:
+        unit_num, unit, form_num, form = match.groups()
+        return unit_num.strip(), unit.strip(), form_num.strip(), form.strip()
+    else:
+        return np.nan, np.nan, np.nan, np.nan
 
 # Assigns each of the separated unit dosage parts from the description to new columns
 def unit_dosage(df, column='PACKAGEDESCRIPTION'):
@@ -319,7 +321,7 @@ def dfg_std(dfg):
         dfg = dfg.upper()
     return dfg
 
-# Standardizees the formatting for the 'Dosage Form' column
+# Standardizes the formatting for the 'Dosage Form' column
 def dosage_form_std(row):
     df_list = ["Injectable Solution", "Injectable Suspension", "Injection"]
     if row['DF'] in df_list or row['DF'] == "nan":
@@ -468,11 +470,11 @@ def validate_csv(new_data_csv, reference_csv='universal-med-ids.csv'):
         old_value = row['QUMI Code_old']
         new_value = row['QUMI Code_new']
         if pd.isna(old_value) and not pd.isna(new_value):
-            print(f"{row['NDC']}:\tNaN -> {new_value}\t{row['Description_new']}")
+            print(f"{row['NDC']}:\tNaN -> {new_value}\t{row['Description_new']} \t{row['Strength_new']} {row['Measure_new']}")
         elif not pd.isna(old_value) and pd.isna(new_value):
-            print(f"{row['NDC']}:\t{old_value} -> NaN\t{row['Description_old']}")
+            print(f"{row['NDC']}:\t{old_value} -> NaN\t{row['Description_old']} \t{row['Strength_old']} {row['Measure_old']}")
         elif old_value != new_value:
-            print(f"{row['NDC']}:\t{old_value} -> {new_value}\t{row['Description_new']}")
+            print(f"{row['NDC']}:\t{old_value} -> {new_value}\t{row['Description_new']} \t{row['Strength_new']} {row['Measure_new']}")
 
 def main(operation, filename, log_level):
     # Set up logging level
@@ -544,6 +546,7 @@ def main(operation, filename, log_level):
     ndc_data['RXCUI'] = ndc_data['RXCUI'].apply(rxcui_std)
     ndc_data['DOSAGEFORMNAME2'] = ndc_data['DOSAGEFORMNAME'].apply(dosage_form)
     ndc_data['ROUTENAME2'] = ndc_data['ROUTENAME'].apply(route)
+    ndc_data = ndc_data.astype(str)
     ndc_data['DOSE'] = ndc_data['DOSE'].apply(dose_simplified)
     ndc_data['DOSAGEFORMNAME2'] = ndc_data.apply(route_to_dosage, axis=1)
     ndc_data = ndc_data.astype(str)

--- a/universal-med-ids.log
+++ b/universal-med-ids.log
@@ -1,3 +1,2423 @@
+6/18/2024:
+80661-0010-01:	1p1cpee -> 8y356xa	Aluminum sesquichlorohydrate 37500 mg Bottle [Myhealth Mood Care Unissex] 	37500 mg
+69423-0382-10:	n36amry -> rnwdxx1	Aluminum chlorohydrate 25145 mg Can [Secret Dry Light Essentials] 	25145 mg
+69423-0384-10:	n36amry -> rnwdxx1	Aluminum chlorohydrate 25145 mg Can [Secret Outlast Completely Clean Dry] 	25145 mg
+69423-0478-10:	n36amry -> rnwdxx1	Aluminum chlorohydrate 25145 mg Can [Secret Outlast Protecting Dry] 	25145 mg
+82570-0013-01:	2ejmg9p -> jvf49tt	Noni moringa capsules 100.0; 100.0; 100.0; 110 mg; mg; mg; mg Bottle [Desour Crimson] 	100; 100; 100; 110 mg; mg; mg; mg
+82570-0012-01:	m8jc52x -> 71g9fmj	Ashwagandha black maca extract powde 50.0; 50.0; 260 mg; mg; mg Bottle [Debaosheng] 	50; 50; 260 mg; mg; mg
+82570-0006-01:	xe733fx -> vbc736j	Nmn food capsules 50.0; 100.0; 150.0; 110.0; 50 mg; mg; mg; mg; mg Capsule [Detijian Nadh] 	50; 100; 150; 110; 50 mg; mg; mg; mg; mg
+75269-0014-01:	31xgre5 -> p3zq98e	Sanitary wipes 0 mg Patch [Mioszzi Sanitary Wipes] 	0 mg
+75269-0014-02:	31xgre5 -> p3zq98e	Sanitary wipes 0 mg Patch [Mioszzi Sanitary Wipes] 	0 mg
+75670-0001-01:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0001-02:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0001-03:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0001-04:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0002-01:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0002-02:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0002-03:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0002-04:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+75670-0003-02:	36gpcb2 -> p7ceqan	Benzalkonium chloride,didecyldimonium chloride 0.01; 0.01 mg; mg Pouch [Sanitizing Wipes] 	0.01; 0.01 mg; mg
+70888-0002-01:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-02:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-03:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-04:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-05:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-06:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-07:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-08:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-09:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+70888-0002-10:	da1tdmx -> 8gjm2f3	Ethyl alcohol 0.04 mL Pouch [Antibacterial Wet Wipes] 	0.04 mL
+34645-0006-01:	dzpf5z7 -> 2zjkt9h	Isopropyl alcohol 0.28 mL Patch [Alcohol Preps Sterile] 	0.28 mL
+75670-0010-01:	kh63cvs -> 5cmsvgp	Benzalkonium chloride 0.01; 0.02 mg; mg Package [30 Soft Wipes] 	0.01; 0.02 mg; mg
+75670-0011-01:	kh63cvs -> ehdc2qn	Benzalkonium chloride 0.01; 0.01 mg; mg Package [60 Soft Wipes] 	0.01; 0.01 mg; mg
+86815-0003-04:	kws7bxk -> 172s3a8	Benzalkonium chloride 0.55 mg Patch [Deep Fresh Antibacterial Wet Wipes] 	0.55 mg
+86815-0003-06:	kws7bxk -> 13vym7t	Benzalkonium chloride 0.7 mg Patch [Deep Fresh Antibacterial Wet Wipes] 	0.7 mg
+86815-0003-08:	kws7bxk -> ygj3b1x	Benzalkonium chloride 1.1 mg Patch [Deep Fresh Antibacterial Wet Wipes] 	1.1 mg
+78806-0300-30:	sqkhtt3 -> hqgwfr6	0.13% benzakonium chloride 0.07 mg Package [Sanitizing Wipes] 	0.07 mg
+78806-0300-40:	sqkhtt3 -> hqgwfr6	0.13% benzakonium chloride 0.07 mg Package [Sanitizing Wipes] 	0.07 mg
+66820-0300-03:	7yhtw27 -> szsc99j	Titanium dioxide, zinc oxide 64.23; 38.75 mg; mg Packet [Decorte Aq Uv Protection] 	64.23; 38.75 mg; mg
+13733-0141-03:	cqh5pvg -> gh0n14k	Zinc oxide, titanium dioxide, octinoxate 75.0; 42.0; 70 mg; mg; mg Packet [Missha M Perfect Cover Bb No 13] 	75; 42; 70 mg; mg; mg
+72104-0589-83:	jz2gvj2 -> bwthk0b	Octinoxate, homosalate, octisalate, oxybenzone and avobenzone 750.0; 3100.0; 3700.0; 2500.0; 1550 mg; mg; mg; mg; mg Jar [Introstem Stem Cell Active Defense] 	750; 3100; 3700; 2500; 1550 mg; mg; mg; mg; mg
+00259-3192-05:	mfwdqa5 -> 3d6qvm7	Avobenzone, octocrylene, and oxybenzone 15.0; 50.0; 30 mg; mg; mg Packet [Mederma] 	15; 50; 30 mg; mg; mg
+51824-0003-14:	mkyq48d -> cqgrdmq	Bacitracin zinc 450 [USP'U] Packet [Careall Bacitracin] 	450 [USP'U]
+51824-0003-25:	mkyq48d -> cqgrdmq	Bacitracin zinc 450 [USP'U] Packet [Careall Bacitracin] 	450 [USP'U]
+82942-1002-01:	raxbajn -> 6eqzfta	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate, polymyxin b 360.0; 3.15; 4500 [CFU]; mg; [CFU] Packet [Triple Antibiotic] 	360; 3.15; 4500 [CFU]; mg; [CFU]
+69396-0069-09:	w0t5kdf -> xkktxke	Hydrocortisone 9 mg Packet [Hydrocortisone 1%] 	9 mg
+13733-0141-02:	xa13n4r -> 2y7y9bs	Zinc oxide, titanium dioxide, octinoxate 1500.0; 838.0; 1400 mg; mg; mg Tube [Missha M Perfect Cover Bb No 13] 	1500; 838; 1400 mg; mg; mg
+72085-0147-04:	xwefvxa -> jmkvf7k	Octinoxate, octisalate, octocrylene, zinc oxide 8475.0; 5650.0; 5650.0; 5650 mg; mg; mg; mg Tube [Sea Star Sparkle Spf-50 Mango-Tango] 	8475; 5650; 5650; 5650 mg; mg; mg; mg
+61596-0102-10:	sr7tn8v -> e4q2g3c	Sodium fluoride 0.0024 mg/mg Toothpaste 	1.1 mg
+61596-0103-10:	sr7tn8v -> e4q2g3c	Sodium fluoride 0.0024 mg/mg Toothpaste 	1.1 mg
+40057-1011-07:	z9nb24t -> hsrkgsh	Sodium monofluorophosphate 0.0076 mg/mg Toothpaste 	2 mg
+11822-1616-09:	as5321v -> m8cs3mw	Benzocaine 50.0; 1.25 mg; mg Blister Pack [Toothache And Gum Relief Cushions] 	50; 1.25 mg; mg
+71584-0108-01:	ssq3m2p -> dhbek0v	Benzalkonium chloride 0.6 mg Pouch [Antibacterial Bandages] 	0.6 mg
+71584-0108-02:	ssq3m2p -> dhbek0v	Benzalkonium chloride 0.6 mg Pouch [Antibacterial Bandages] 	0.6 mg
+71584-0108-03:	ssq3m2p -> dhbek0v	Benzalkonium chloride 0.6 mg Pouch [Antibacterial Bandages] 	0.6 mg
+71584-0108-04:	ssq3m2p -> dhbek0v	Benzalkonium chloride 0.6 mg Pouch [Antibacterial Bandages] 	0.6 mg
+71584-0108-05:	ssq3m2p -> dhbek0v	Benzalkonium chloride 0.6 mg Pouch [Antibacterial Bandages] 	0.6 mg
+71584-0108-06:	ssq3m2p -> dhbek0v	Benzalkonium chloride 0.6 mg Pouch [Antibacterial Bandages] 	0.6 mg
+61957-2955-02:	egtee2s -> 18dcd42	Octinoxate, titanium dioxide 21.0; 12.25 mg; mg Packet [Forever 24H Wear High Perfection Skin Caring Foundation With Sunscreen Broad Spectrum Spf 35 Lasting Comfort And Care] 	21; 12.25 mg; mg
+61957-2959-02:	egtee2s -> 18dcd42	Octinoxate, titanium dioxide 21.0; 12.25 mg; mg Packet [Forever 24H Wear High Perfection Skin Caring Foundation With Sunscreen Broad Spectrum Spf 35 Lasting Comfort And Care] 	21; 12.25 mg; mg
+61957-2966-02:	egtee2s -> 18dcd42	Octinoxate, titanium dioxide 21.0; 12.25 mg; mg Packet [Forever 24H Wear High Perfection Skin Caring Foundation With Sunscreen Broad Spectrum Spf 35 Lasting Comfort And Care] 	21; 12.25 mg; mg
+61957-2973-02:	egtee2s -> 18dcd42	Octinoxate, titanium dioxide 21.0; 12.25 mg; mg Packet [Forever 24H Wear High Perfection Skin Caring Foundation With Sunscreen Broad Spectrum Spf 35 Lasting Comfort And Care] 	21; 12.25 mg; mg
+49817-2035-06:	ya85fb0 -> j54wrvn	Titanium dioxide 8.8 mg Bottle [Lessentiel Natural Glow Foundation 16H Wear With Sunscreen Broad Spectrum Spf 20 01N Tres Clair/Very Light] 	8.8 mg
+49817-2038-06:	ya85fb0 -> j54wrvn	Titanium dioxide 8.8 mg Bottle [Lessentiel Natural Glow Foundation 16H Wear With Sunscreen Broad Spectrum Spf 20] 	8.8 mg
+49817-2040-06:	ya85fb0 -> j54wrvn	Titanium dioxide 8.8 mg Bottle [Lessentiel Natural Glow Foundation 16H Wear With Sunscreen Broad Spectrum Spf 20] 	8.8 mg
+52261-0001-02:	1vdav5t -> ja8nt6h	Alcohol 0.1 L Tube [Cosco Hand Sanitizer 75%] 	0.1 L
+51531-0850-00:	2pgp59k -> 37fv7jh	Avobenzone, homosalate, octisalate, octocrylene 12.5; 45.0; 25.0; 15 mg; mg; mg; mg Packet [Mary Kay Foundation Primer] 	12.5; 45; 25; 15 mg; mg; mg; mg
+61010-1111-04:	3fhe4kw -> ecsxnmk	Alcohol 255542.98 mg Bottle [Instant Hand Sanitizer] 	255542.98 mg
+62881-0001-01:	3vym9zs -> vmv83z6	Ethyl alcohol 0.71 L Bottle [Instant Hand Sanitizer] 	0.71 L
+78434-0100-32:	4h2g585 -> 58tz2q5	Ethyl alcohol 0.76 L Bottle [Accurate Labs Antiseptic Hand Sanitizer] 	0.76 L
+61010-1111-00:	56n1kyx -> vh46m1n	Alcohol 31875.34 mg Bottle [Instant Hand Sanitizer] 	31875.34 mg
+61010-1111-01:	7e15x27 -> 5y34csy	Alcohol 63750.68 mg Bottle [Instant Hand Sanitizer] 	63750.68 mg
+77396-0002-02:	7yes0bz -> gex1q3x	Didecyldimonium chloride and benzalkonium chloride liquid 75.0; 187.5 mg; mg Bottle [Sanivir Gel Plus Hand Sanitizer] 	75; 187.5 mg; mg
+78263-0326-43:	836d1cq -> esg91rj	Alcohol 0.66 L Bottle [Ultra Clean Antiseptic Hand Sanitizer] 	0.66 L
+61010-1111-06:	91dxd4x -> pye89j9	Alcohol 128041.62 mg Bottle [Instant Hand Sanitizer] 	128041.62 mg
+82996-0001-01:	99wzn6k -> vnmhm50	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate 200.0; 17.5; 2500 [IU]; mg; [IU] Pouch [First Aid Antibiotic] 	200; 17.5; 2500 [IU]; mg; [IU]
+78785-0001-05:	9ave7be -> hmkc8tc	Alcohol 0.6 mL Applicator [Virus Gone] 	0.6 mL
+52261-0000-01:	af4zqz4 -> s47wjmj	Alcohol 0.05 L Tube [Cosco Hand Saniitizer 80%] 	0.05 L
+78434-0100-04:	b59ccas -> 18r7fa0	Ethyl alcohol 0.1 L Bottle [Accurate Labs Antiseptic Hand Sanitizer] 	0.1 L
+78434-0100-02:	g84xkr4 -> m5qxsep	Ethyl alcohol 0.05 L Bottle [Accurate Labs Antiseptic Hand Sanitizer] 	0.05 L
+78434-0100-08:	heyzw5b -> 2j7s8qz	Ethyl alcohol 0.2 L Bottle [Accurate Labs Antiseptic Hand Sanitizer] 	0.2 L
+76944-0123-02:	hkjb8jw -> smq2scy	Alcohol 0.62 KG/KG Kg [Triton Hand Sanitizer Gel] 	0.62 KG/KG
+49967-0637-01:	jj5sr4s -> 18r7fa0	Alcohol 0.1 L Bottle [Saloncentric Take Care Antiseptic Hand Sanitizer] 	0.1 L
+49967-0998-01:	jj5sr4s -> 18r7fa0	Alcohol 0.1 L Tube [Kiehls Since 1851 Clean Strength Antiseptic Hand Sanitizer] 	0.1 L
+52261-0001-01:	p7de0wx -> sha58r8	Alcohol 0.04 L Tube [Cosco Hand Sanitizer 75%] 	0.04 L
+78434-0100-16:	qmxz5w6 -> 8nrgfcm	Ethyl alcohol 0.38 L Bottle [Accurate Labs Antiseptic Hand Sanitizer] 	0.38 L
+52261-0000-02:	r9hm7ry -> z3txm08	Alcohol 0.1 L Tube [Cosco Hand Saniitizer 80%] 	0.1 L
+52261-0001-03:	rj7fzp5 -> pg99gt3	Alcohol 0.18 L Tube [Cosco Hand Sanitizer 75%] 	0.18 L
+77411-0004-04:	rqa4p0f -> 1gn1k0y	Hand sanitizer 0.67 KG/KG Kg [Clean N Fresh 01] 	0.67 KG/KG
+77411-0004-55:	rqa4p0f -> 1gn1k0y	Hand sanitizer 0.67 KG/KG Kg [Clean N Fresh 01] 	0.67 KG/KG
+50332-5394-01:	ryrxfcc -> 5t9c1e8	Antiseptic gel 558 mg Packet [Hand Sanitizer] 	558 mg
+50332-5394-02:	ryrxfcc -> 5t9c1e8	Antiseptic gel 558 mg Packet [Hand Sanitizer] 	558 mg
+61010-1111-05:	sc89t47 -> anzbwth	Alcohol 432208 mg Box [Instant Hand Sanitizer] 	432208 mg
+73408-0511-73:	v6e07cs -> jbqqn7w	Alcohol gel 907.64 mg Packet [Crane Safety Hand Sanitizer] 	907.64 mg
+70082-0500-01:	vqcvd5f -> x617qyn	Lidocaine HCl 16.2 mg Pouch 	16.2 mg
+78263-0326-45:	wg9fffb -> nh6e946	Alcohol 0.17 L Bottle [Ultra Clean Antiseptic Hand Sanitizer] 	0.17 L
+76569-0113-09:	wt06x37 -> esg91rj	Alcohol 0.66 KG/KG Kg [Hand Sanitizer] 	0.66 KG/KG
+61010-8202-00:	x2fk9mg -> 5r0waj0	Menthol 6.16 mg Bottle [Analgesic] 	6.16 mg
+63824-0259-04:	x4m1cbk -> 853c3xj	Benzocaine 35 mg Pouch [Ky Duration For Men] 	35 mg
+63824-0259-05:	x4m1cbk -> 853c3xj	Benzocaine 35 mg Pouch [Ky Duration For Men] 	35 mg
+11344-0544-72:	xc1nxgj -> 45yjtf8	Ethyl alcohol 209.8 mg Bottle [Hand Sanitizer] 	209.8 mg
+52261-0000-03:	y60vfvs -> tyrqcvx	Alcohol 0.2 L Tube [Cosco Hand Saniitizer 80%] 	0.2 L
+47682-0511-12:	z0v7ygb -> p4ba13n	Alcohol 907.64 mg Packet [Hand Sanitizer] 	907.64 mg
+47682-0511-73:	z0v7ygb -> p4ba13n	Alcohol 907.64 mg Packet [Hand Sanitizer] 	907.64 mg
+55670-0112-01:	z0v7ygb -> szrrctq	Alcohol 486.23 mg Packet [Hand Sanitizer] 	486.23 mg
+61010-1111-03:	z0v7ygb -> m2r2e8h	Alcohol 1998.96 mg Packet [Instant Hand Sanitizer] 	1998.96 mg
+61010-1111-08:	z0v7ygb -> p4ba13n	Alcohol 907.64 mg Packet [Instant Hand Sanitizer] 	907.64 mg
+71338-0124-73:	z0v7ygb -> k5920qv	Ethyl alcohol 66.5% 499.2 mg Packet [Ecolab Hand Sanitizer] 	499.2 mg
+10014-0001-09:	3zmnrf7 -> y1g91k1	Oxygen 99 % Gas for Inhalation [Lif-O-Gen] 	476.2 mL
+00093-4147-56:	42fnc8a -> gjh374c	Levalbuterol 2.5 mg/mL Inhalation Solution [Xopenex] 	1.25 mg
+00378-6993-93:	42fnc8a -> gjh374c	Levalbuterol 2.5 mg/mL Inhalation Solution [Xopenex] 	1.25 mg
+17478-0171-30:	42fnc8a -> gjh374c	Levalbuterol 2.5 mg/mL Inhalation Solution [Xopenex] 	1.25 mg
+65862-0942-03:	42fnc8a -> gjh374c	Levalbuterol 2.5 mg/mL Inhalation Solution [Xopenex] 	1.25 mg
+10014-0001-11:	4s8egsq -> kagw2gc	Oxygen 99 % Gas for Inhalation [Lif-O-Gen] 	896.94 mL
+50474-0500-15:	5z9nz5b -> 1bk1c4v	Midazolam 50 mg/mL Nasal Spray [Nayzilam] 	5 mg
+00093-2165-68:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+00591-2971-99:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+00781-7176-12:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+45802-0811-84:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+50090-5908-00:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+51662-1240-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+51662-1240-02:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+51662-1620-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+51662-1620-02:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+55700-0457-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+55700-0985-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+63629-9321-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+69547-0353-02:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+71205-0707-02:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+80425-0259-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+83008-0007-01:	6858zgh -> 2wd4pkw	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+59467-0679-01:	7eq32d6 -> wp533c5	Naloxone HCl 80 mg/mL Nasal Spray [Kloxxado] 	8 mg
+00527-1859-43:	7mk8654 -> 3z0kp37	Sumatriptan 20 mg/ACTUAT Nasal Spray [Imitrex] 	20 mg
+00527-1818-43:	9d1rpym -> 67prwse	Sumatriptan 5 mg/ACTUAT Nasal Spray [Imitrex] 	5 mg
+10014-0001-10:	9kf2g8d -> j6vbqwm	Oxygen 99 % Gas for Inhalation [Lif-O-Gen] 	697.95 mL
+00245-0812-61:	9p3863h -> wq19f4q	Sumatriptan 10 mg/ACTUAT Nasal Spray [Tosymra] 	10 mg
+00924-5401-01:	9qcace7 -> zjv3n1z	Ammonia 150 mg/mL Nasal Inhalant 	45 mg
+00924-5401-02:	9qcace7 -> zjv3n1z	Ammonia 150 mg/mL Nasal Inhalant 	45 mg
+46414-3333-02:	9qcace7 -> zjv3n1z	Ammonia 150 mg/mL Nasal Inhalant 	45 mg
+71872-7261-05:	ape5116 -> w7vfrfd	Ammonia 150 mg/mL Nasal Inhalant 	50 mg
+10014-0001-08:	as1ggnf -> zd3wrc2	Oxygen 99 % Gas for Inhalation [Lif-O-Gen] 	420.75 mL
+00273-0104-10:	cxnyv98 -> zjv3n1z	Ammonia 150 mg/mL Nasal Inhalant 	45 mg
+71205-0528-02:	d9rnvw6 -> pdreeht	Naloxone HCl 40 mg/mL Nasal Spray [Narcan] 	4 mg
+00487-9901-02:	hd1mraj -> v1vx2r4	Albuterol 5 mg/mL Inhalation Solution [Ventolin] 	2.5 mg
+00487-9901-30:	hd1mraj -> v1vx2r4	Albuterol 5 mg/mL Inhalation Solution [Ventolin] 	2.5 mg
+55154-4350-05:	hd1mraj -> v1vx2r4	Albuterol 5 mg/mL Inhalation Solution [Ventolin] 	2.5 mg
+10014-0005-10:	j50z442 -> s5zxh7s	Carbon dioxide 99 % Gas for Inhalation 	490.05 mL
+00487-2784-01:	m3yn5bt -> 7hcphk1	Racepinephrine 22.5 mg/mL Inhalation Solution [Asthmanefrin] 	11.25 mg
+00487-5901-99:	m3yn5bt -> 7hcphk1	Racepinephrine 22.5 mg/mL Inhalation Solution [Asthmanefrin] 	11.25 mg
+10014-0001-07:	mk96y7z -> xj3ty64	Oxygen 99 % Gas for Inhalation [Lif-O-Gen] 	208 mL
+46414-2222-08:	p0ysnx5 -> 81jzxr0	Amyl nitrite 0.3 mL Nasal Inhalant 	300 mg
+10014-0005-11:	p8k64hf -> z3jr9pq	Carbon dioxide 99 % Gas for Inhalation 	772.2 mL
+68599-7100-01:	ra4df75 -> c26ab4y	Ammonia 150 mg/mL Nasal Inhalant 	22.5 mg
+67777-0251-01:	sm059x8 -> w7vfrfd	Ammonia 150 mg/mL Nasal Inhalant 	50 mg
+69547-0212-04:	w4qyhxn -> e8ps98a	Naloxone HCl 20 mg/mL Nasal Spray [Narcan] 	2 mg
+69547-0212-24:	w4qyhxn -> e8ps98a	Naloxone HCl 20 mg/mL Nasal Spray [Narcan] 	2 mg
+81944-0002-01:	zrpr8nb -> j1z8tx9	Ko2, ca(oh)2 2.5 mg Patch [O2 Patch] 	2.5 mg
+55670-0710-01:	zyxcezg -> mjz32f7	Ammonia 150 mg/mL Nasal Inhalant 	45 mg
+00075-0624-30:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+00075-8013-10:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+00548-5601-00:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+00703-8530-23:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+00781-3133-63:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+00781-3238-63:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+00955-1003-10:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+11797-0757-06:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+16714-0006-10:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+55154-3540-05:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+60505-0791-00:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+63323-0533-83:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+63323-0533-93:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+63323-0559-65:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+63323-0559-93:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+68001-0457-42:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+70710-1757-06:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+71288-0410-81:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+71288-0432-81:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+71288-0432-92:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+81952-0123-23:	13qryj5 -> e344gc5	0.3 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	30 mg
+62935-0453-45:	1he8mg1 -> 2xvkm3v	0.375 mL leuprolide acetate 120 mg/mL Prefilled Syringe [Eligard] 	0.38 mL
+58160-0976-20:	1nx3aec -> yp4qx0n	0.5 mL meningococcal group B vaccine 0.1 mg/mL / Neisseria meningitidis serogroup B recombinant FHBP fusion protein antigen 0.1 mg/mL / Neisseria meningitidis serogroup B recombinant NHBA fusion protein antigen 0.1 mg/mL / Neisseria meningitidis serogroup B strain NZ98/254 outer membrane vesicle 0.05 mg/mL Prefilled Syringe [Bexsero] 	0.05; 0.05; 0.05; 0.03 mg; mg; mg; mg
+55513-0740-10:	1zn0adt -> 6ngtrgq	Etelcalcetide 5 mg/mL Vial [Parsabiv] 	2.5 mg
+00003-2814-11:	23ct33d -> 81038s8	0.4 mL abatacept 125 mg/mL Prefilled Syringe [Orencia] 	50 mg
+00003-2818-11:	23ct33d -> csg9gje	0.7 mL abatacept 125 mg/mL Prefilled Syringe [Orencia] 	87.5 mg
+55154-2380-05:	23n59t8 -> vf9edgg	Heparin sodium 5000 [USP'U] Cartridge 	5000 [USP'U]
+63323-0543-02:	23n59t8 -> vf9edgg	Heparin sodium 5000 [USP'U] Vial 	5000 [USP'U]
+63323-0543-13:	23n59t8 -> vf9edgg	Heparin sodium 5000 [USP'U] Vial 	5000 [USP'U]
+71839-0118-25:	23n59t8 -> vf9edgg	Heparin sodium 5000 [USP'U] Vial 	5000 [USP'U]
+58160-0810-52:	26g6fsb -> 9xmpcx1	Diphtheria and tetanus toxoids and acellular pertussis vaccine adsorbed 0.03; 0.01; 0.03; 10.0; 25 mg; mg; mg; [IU]; [IU] Syringe [Infanrix] 	0.03; 0.01; 0.03; 10; 25 mg; mg; mg; [IU]; [IU]
+68803-0722-05:	2b178g8 -> 6kpyz9y	Brilliant blue g 0.01 mg Syringe [Tissueblue] 	0.01 mg
+00005-2000-02:	2b3mz95 -> 4ks7ad7	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 10A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 11A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 12F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 15B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 22F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 33F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0088 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 8 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL Prefilled Syringe [Prevnar 20] 	0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+00005-2000-10:	2b3mz95 -> 4ks7ad7	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 10A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 11A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 12F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 15B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 22F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 33F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0088 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 8 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL Prefilled Syringe [Prevnar 20] 	0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+50090-6026-00:	2b3mz95 -> 4ks7ad7	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 10A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 11A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 12F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 15B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 22F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 33F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0088 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 8 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL Prefilled Syringe [Prevnar 20] 	0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+55513-0027-04:	2hkkqwp -> bs38ny3	0.3 mL darbepoetin alfa 0.5 mg/mL Prefilled Syringe [Aranesp] 	0.15 mg
+55513-0028-01:	2hkkqwp -> n3hap78	0.4 mL darbepoetin alfa 0.5 mg/mL Prefilled Syringe [Aranesp] 	0.2 mg
+55513-0111-01:	2hkkqwp -> yq0heey	0.6 mL darbepoetin alfa 0.5 mg/mL Prefilled Syringe [Aranesp] 	0.3 mg
+51759-0630-10:	2kc0gq3 -> 4j06ajb	0.35 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	125 mg
+51759-0630-11:	2kc0gq3 -> 4j06ajb	0.35 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	125 mg
+51759-0740-10:	2kc0gq3 -> qvs75w4	0.42 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	150 mg
+51759-0740-11:	2kc0gq3 -> qvs75w4	0.42 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	150 mg
+51759-0850-10:	2kc0gq3 -> z4jja6x	0.56 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	200 mg
+51759-0850-11:	2kc0gq3 -> z4jja6x	0.56 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	200 mg
+51759-0960-10:	2kc0gq3 -> wq85g3k	0.7 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	250 mg
+51759-0960-11:	2kc0gq3 -> wq85g3k	0.7 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	250 mg
+42515-0002-01:	2kesmfh -> egeysyc	0.5 mL Japanese encephalitis virus vaccine Nakayama-NIH strain, inactivated 0.012 mg/mL Prefilled Syringe [Ixiaro] 	6 [ARB'U]
+00173-0478-00:	2qczj1w -> efcb28n	0.5 mL sumatriptan 12 mg/mL Cartridge [Imitrex] 	6 mg
+00173-0479-00:	2qczj1w -> efcb28n	0.5 mL sumatriptan 12 mg/mL Cartridge [Imitrex] 	6 mg
+49281-0403-65:	2wgdszs -> ad5jvqc	0.5 mL influenza A virus A/Michigan/45/2015 (H1N1) antigen 0.12 mg/mL / influenza A virus A/Singapore/INFIMH-16-0019/2016 (H3N2) antigen 0.12 mg/mL / influenza B virus B/Maryland/15/2016 antigen 0.12 mg/mL Prefilled Syringe [Fluzone 2018-2019] 	0.06; 0.06; 0.06 mg; mg; mg
+68135-0756-20:	317x62b -> q086c2e	0.5 mL pegvaliase-pqpz 20 mg/mL Prefilled Syringe [Palynziq] 	10 mg
+70114-0440-01:	3jhd53e -> fybn6qe	0.05 mL ranibizumab-eqrn 6 mg/mL Vial [Cimerli] 	0.3 mg
+66220-0810-22:	3k9pa82 -> m3hqv0q	0.4 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	10 mg
+78670-0140-02:	3mc4x19 -> ax9k4v6	0.5 mL naloxone HCl 10 mg/mL Prefilled Syringe [Zimhi] 	5 mg
+51759-0305-10:	3n1jbfn -> 69q9xxe	0.14 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	50 mg
+51759-0305-11:	3n1jbfn -> 69q9xxe	0.14 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	50 mg
+51759-0410-10:	3n1jbfn -> ma3vkse	0.21 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	75 mg
+51759-0410-11:	3n1jbfn -> ma3vkse	0.21 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	75 mg
+61314-0318-01:	3nm0kfb -> ed22vs0	0.5 mL filgrastim-sndz 0.6 mg/mL Prefilled Syringe [Zarxio] 	0.3 mg
+61314-0318-10:	3nm0kfb -> ed22vs0	0.5 mL filgrastim-sndz 0.6 mg/mL Prefilled Syringe [Zarxio] 	0.3 mg
+62064-0241-30:	3z5tgq8 -> zj20342	Tesamorelin 2 mg Vial [Egrifta] 	0.5 mL
+69945-0132-06:	41ab82v -> vkqzyxa	Indium in 111 chloride 5 MCI Vial 	5 MCI
+00052-0313-01:	41n8qnj -> ah6xf2r	0.36 mL follitropin beta 833 UNT/mL Cartridge [Follistim] 	350 [IU]
+00052-0313-81:	41n8qnj -> ah6xf2r	0.36 mL follitropin beta 833 UNT/mL Cartridge [Follistim] 	350 [IU]
+00052-0316-01:	41n8qnj -> p8dhk5p	0.72 mL follitropin beta 833 UNT/mL Cartridge [Follistim] 	650 [IU]
+00052-0316-81:	41n8qnj -> p8dhk5p	0.72 mL follitropin beta 833 UNT/mL Cartridge [Follistim] 	650 [IU]
+55513-0025-04:	43ge0pm -> 36rk7fc	0.5 mL darbepoetin alfa 0.2 mg/mL Prefilled Syringe [Aranesp] 	0.1 mg
+76420-0086-04:	46nc95a -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+50242-0138-01:	47m6wk0 -> dy3kkdz	0.9 mL tocilizumab 180 mg/mL Prefilled Syringe [Actemra] 	162 mg
+50242-0138-86:	47m6wk0 -> dy3kkdz	0.9 mL tocilizumab 180 mg/mL Prefilled Syringe [Actemra] 	162 mg
+11704-0107-01:	47vp9jz -> b4kaf3r	0.3 mL atropine sulfate 0.833 mg/mL Auto-Injector [Atropen] 	0.25 mg
+51662-1223-01:	4dg7j34 -> q6s9rep	NDA020800 0.3 mL epinephrine 1 mg/mL Auto-Injector [Adrenaclick] 	0.3 mg
+54436-0022-01:	4dvjgbg -> w73ac8a	0.4 mL methotrexate 56.3 mg/mL Auto-Injector [Otrexup] 	22.5 mg
+54436-0022-03:	4dvjgbg -> w73ac8a	0.4 mL methotrexate 56.3 mg/mL Auto-Injector [Otrexup] 	22.5 mg
+54436-0022-04:	4dvjgbg -> w73ac8a	0.4 mL methotrexate 56.3 mg/mL Auto-Injector [Otrexup] 	22.5 mg
+44087-0188-01:	4j7qwdj -> r3zqt02	Interferon beta-1a 0.5 mL Pack [Rebif Rebidose] 	0.5 mL
+59137-0505-01:	4qdfd58 -> 39esf2j	0.15 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	7.5 mg
+59137-0505-04:	4qdfd58 -> 39esf2j	0.15 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	7.5 mg
+59137-0550-01:	4qdfd58 -> qz2ak0e	0.6 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	30 mg
+59137-0550-04:	4qdfd58 -> qz2ak0e	0.6 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	30 mg
+58160-0848-11:	4thh53x -> fdjm1kg	0.5 mL respiratory syncytial virus pre-fusion F protein, recombinant 0.24 mg/mL Vial [Arexvy] 	0.5 mL
+10454-0710-10:	544z2m7 -> 3zkwp1z	0.5 mL rimabotulinumtoxinB 5000 UNT/mL Vial [Myobloc] 	2500 [USP'U]
+72065-0121-11:	546n2ms -> 6p3sea7	0.2 mL glucagon 5 mg/mL Auto-Injector [Gvoke] 	1 mg
+72065-0121-12:	546n2ms -> 6p3sea7	0.2 mL glucagon 5 mg/mL Auto-Injector [Gvoke] 	1 mg
+58406-0010-04:	54ysqqp -> w7nxnrz	0.5 mL etanercept 50 mg/mL Prefilled Syringe [Enbrel] 	25 mg
+58406-0032-04:	54ysqqp -> wk12bnc	1 mL etanercept 50 mg/mL Auto-Injector [Enbrel] 	50 mg
+58406-0445-04:	54ysqqp -> wk12bnc	1 mL etanercept 50 mg/mL Auto-Injector [Enbrel] 	50 mg
+58406-0455-04:	54ysqqp -> w7nxnrz	0.5 mL etanercept 50 mg/mL Prefilled Syringe [Enbrel] 	25 mg
+00078-0827-60:	558qxfr -> yaeqpy8	Brolucizumab 6 mg Syringe [Beovu] 	6 mg
+00078-0827-98:	558qxfr -> yaeqpy8	Brolucizumab 6 mg Syringe [Beovu] 	6 mg
+80777-0283-99:	56c8hyr -> jf0ftr8	SARS-CoV-2 (COVID-19) vaccine, mRNA-1273 0.025 mg/mL / SARS-CoV-2 (COVID-19) vaccine, mRNA-1273 OMICRON (BA.4/BA.5) 0.025 mg/mL Vial 	0.01; 0.01 mg; mg
+76045-0009-06:	56n2k7r -> 6gh2twh	0.5 mL hydromorphone HCl 1 mg/mL Prefilled Syringe [Dilaudid] 	0.5 mg
+70461-0122-03:	589npwg -> rzmbhz0	0.5 mL influenza A virus A/Cambodia/e0826360/2020 (H3N2) antigen 0.03 mg/mL / influenza A virus A/Victoria/2570/2019 (H1N1) antigen 0.03 mg/mL / influenza B virus B/Phuket/3073/2013 antigen 0.03 mg/mL / influenza B virus B/Victoria/705/2018 antigen 0.03 mg/mL Prefilled Syringe [Fluad Quadrivalent 2021-2022] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+49502-0501-92:	5bw8dz2 -> 32vafb9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+49281-0215-10:	5mnfend -> 29m4myk	Clostridium tetani toxoid antigen (formaldehyde inactivated) and corynebacterium diphtheriae toxoid antigen (formaldehyde inactivated) 5.0; 2 [LF]; [LF] Vial [Tenivac] 	5; 2 [LF]; [LF]
+55513-0098-04:	5pjdxvs -> g5417d7	0.4 mL darbepoetin alfa 0.025 mg/mL Prefilled Syringe [Aranesp] 	0.01 mg
+54436-0025-01:	5qj9n10 -> tz8gnyk	0.4 mL methotrexate 62.5 mg/mL Auto-Injector [Otrexup] 	25 mg
+54436-0025-03:	5qj9n10 -> tz8gnyk	0.4 mL methotrexate 62.5 mg/mL Auto-Injector [Otrexup] 	25 mg
+54436-0025-04:	5qj9n10 -> tz8gnyk	0.4 mL methotrexate 62.5 mg/mL Auto-Injector [Otrexup] 	25 mg
+00078-1007-68:	5r30c8p -> wzja188	0.4 mL ofatumumab 50 mg/mL Pen Injector [Kesimpta] 	20 mg
+00078-1007-98:	5r30c8p -> wzja188	0.4 mL ofatumumab 50 mg/mL Pen Injector [Kesimpta] 	20 mg
+44087-8822-01:	5sra2a0 -> bmtp24j	Interferon beta-1a 0.5 mL Pack [Rebif] 	0.5 mL
+00075-0620-40:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00075-0621-60:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+00075-8014-10:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00075-8016-10:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+00548-5602-00:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00548-5603-00:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+00703-8540-23:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00781-3224-64:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00781-3246-64:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00781-3256-66:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+00781-3356-66:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+00955-1004-10:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+00955-1006-10:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+11797-0758-06:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+11797-0759-06:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+16714-0016-10:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+16714-0026-10:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+55154-3541-05:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+55154-3542-05:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+55154-4028-05:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+55154-6690-05:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+60505-0792-00:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+60505-0792-04:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+60505-0793-00:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+63323-0535-87:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+63323-0535-98:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+63323-0564-65:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+63323-0564-97:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+63323-0566-65:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+63323-0566-98:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+63323-0607-88:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+63323-0607-98:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+68001-0458-42:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+68001-0459-42:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+70710-1758-06:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+70710-1759-06:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+71288-0410-83:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+71288-0410-85:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+71288-0433-83:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+71288-0433-92:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+71288-0434-85:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+71288-0434-92:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+81952-0124-24:	6159wk2 -> 40yjfdf	0.4 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	40 mg
+81952-0126-26:	6159wk2 -> dqhh3vx	0.6 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	60 mg
+00093-2014-12:	638jsyp -> pwp5ksr	Sumatriptan succinate 6 mg Syringe [Sumatriptan] 	6 mg
+16714-0040-02:	638jsyp -> pwp5ksr	Sumatriptan succinate 6 mg Syringe 	6 mg
+43598-0768-23:	638jsyp -> pwp5ksr	Sumatriptan succinate 6 mg Syringe 	6 mg
+47335-0276-41:	638jsyp -> pwp5ksr	Sumatriptan succinate 6 mg Syringe 	6 mg
+55111-0693-12:	638jsyp -> pwp5ksr	Sumatriptan succinate 6 mg Syringe 	6 mg
+60429-0994-02:	638jsyp -> pwp5ksr	Sumatriptan succinate 6 mg Syringe [Sumatriptan] 	6 mg
+66993-0084-79:	638jsyp -> pwp5ksr	Sumatriptan 6 mg Syringe 	6 mg
+66993-0084-98:	638jsyp -> pwp5ksr	Sumatriptan 6 mg Syringe 	6 mg
+55513-0023-04:	6499jkg -> q2m3pxm	0.3 mL darbepoetin alfa 0.2 mg/mL Prefilled Syringe [Aranesp] 	0.06 mg
+75987-0111-11:	64wfwxh -> tenmj99	0.5 mL interferon gamma-1b 0.2 mg/mL Vial [Actimmune] 	0.1 mg
+55513-0413-01:	65rp4fk -> t05ny9j	0.2 mL adalimumab-atto 50 mg/mL Prefilled Syringe [Amjevita] 	10 mg
+00409-1283-05:	6a23psp -> 6gh2twh	0.5 mL hydromorphone HCl 1 mg/mL Prefilled Syringe [Dilaudid] 	0.5 mg
+00409-4264-01:	6a23psp -> 6gh2twh	0.5 mL hydromorphone HCl 1 mg/mL Prefilled Syringe [Dilaudid] 	0.5 mg
+65219-0371-10:	6jjgx6t -> aw123xh	0.6 mL pegfilgrastim-fpgk 10 mg/mL Prefilled Syringe [Stimufend] 	6 mg
+00002-1506-61:	6jzbpys -> z6w5ryj	0.5 mL tirzepatide 5 mg/mL Auto-Injector [Mounjaro] 	2.5 mg
+00002-1506-80:	6jzbpys -> z6w5ryj	0.5 mL tirzepatide 5 mg/mL Auto-Injector [Mounjaro] 	2.5 mg
+00002-1471-80:	6mgqzm8 -> kxzna31	0.5 mL tirzepatide 20 mg/mL Auto-Injector [Mounjaro] 	10 mg
+00006-4943-00:	6ndwtxs -> 5126fws	Pneumococcal vaccine polyvalent 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg Vial [Pneumovax 23] 	0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+44087-1115-01:	6r7n438 -> w7t7vdx	0.5 mL follitropin alfa 600 UNT/mL Pen Injector [Gonal F] 	300 [IU]
+51662-1495-01:	6scmxnv -> eemg9z7	0.4 mL naloxone HCl 5 mg/mL Auto-Injector [Evzio] 	2 mg
+00075-0622-80:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+00075-8018-10:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+00548-5604-00:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+00781-3262-68:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+00781-3428-68:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+00955-1008-10:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+11797-0760-06:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+16714-0036-10:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+55154-3543-05:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+55154-6692-05:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+60505-0794-00:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+60505-0794-04:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+63323-0531-90:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+63323-0531-98:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+63323-0584-65:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+63323-0584-99:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+68001-0460-42:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+70710-1760-06:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+71288-0410-87:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+71288-0435-87:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+71288-0435-92:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+81952-0128-28:	6ss1r48 -> 6vrng8b	0.8 mL enoxaparin sodium 100 mg/mL Prefilled Syringe [Lovenox] 	80 mg
+66220-0807-22:	6tsd3mj -> crj2475	0.3 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	7.5 mg
+49281-0286-01:	6xfyn8p -> 5jankjh	0.5 mL Bordetella pertussis filamentous hemagglutinin vaccine, inactivated 0.01 mg/mL / Bordetella pertussis fimbriae 2/3 vaccine, inactivated 0.01 mg/mL / Bordetella pertussis pertactin vaccine, inactivated 0.006 mg/mL / Bordetella pertussis toxoid vaccine, inactivated 0.02 mg/mL / diphtheria toxoid vaccine, inactivated 30 UNT/mL / tetanus toxoid vaccine, inactivated 10 UNT/mL Vial [Daptacel] 	0.01; 0.01; 0; 0.01; 5; 15 mg; mg; mg; mg; [LF]; [LF]
+49281-0286-05:	6xfyn8p -> 5jankjh	0.5 mL Bordetella pertussis filamentous hemagglutinin vaccine, inactivated 0.01 mg/mL / Bordetella pertussis fimbriae 2/3 vaccine, inactivated 0.01 mg/mL / Bordetella pertussis pertactin vaccine, inactivated 0.006 mg/mL / Bordetella pertussis toxoid vaccine, inactivated 0.02 mg/mL / diphtheria toxoid vaccine, inactivated 30 UNT/mL / tetanus toxoid vaccine, inactivated 10 UNT/mL Vial [Daptacel] 	0.01; 0.01; 0; 0.01; 5; 15 mg; mg; mg; mg; [LF]; [LF]
+49281-0286-10:	6xfyn8p -> 5jankjh	0.5 mL Bordetella pertussis filamentous hemagglutinin vaccine, inactivated 0.01 mg/mL / Bordetella pertussis fimbriae 2/3 vaccine, inactivated 0.01 mg/mL / Bordetella pertussis pertactin vaccine, inactivated 0.006 mg/mL / Bordetella pertussis toxoid vaccine, inactivated 0.02 mg/mL / diphtheria toxoid vaccine, inactivated 30 UNT/mL / tetanus toxoid vaccine, inactivated 10 UNT/mL Vial [Daptacel] 	0.01; 0.01; 0; 0.01; 5; 15 mg; mg; mg; mg; [LF]; [LF]
+00781-3476-12:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+00781-3476-95:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+11797-0157-06:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+11797-0157-09:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+43598-0606-02:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+43598-0606-10:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+55111-0681-02:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+55111-0681-10:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+55150-0233-02:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+55150-0233-10:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+67457-0585-08:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+67457-0595-08:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+70710-1517-06:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+70710-1517-09:	724w330 -> 20eeybz	0.8 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	10 mg
+61755-0005-01:	72qcmbd -> tttqgwt	0.05 mL aflibercept 40 mg/mL Syringe [Eylea] 	2 mg
+61755-0005-54:	72qcmbd -> tttqgwt	0.05 mL aflibercept 40 mg/mL Syringe [Eylea] 	2 mg
+50242-0143-01:	72swwbj -> vb9s387	0.9 mL tocilizumab 180 mg/mL Auto-Injector [Actemra] 	162 mg
+50242-0143-86:	72swwbj -> vb9s387	0.9 mL tocilizumab 180 mg/mL Auto-Injector [Actemra] 	162 mg
+59137-0530-01:	7635fma -> zfab16r	0.4 mL methotrexate 50 mg/mL Auto-Injector [Otrexup] 	20 mg
+59137-0530-04:	7635fma -> zfab16r	0.4 mL methotrexate 50 mg/mL Auto-Injector [Otrexup] 	20 mg
+50242-0096-01:	76f0nrg -> wxyhwvz	0.05 mL faricimab-svoa 120 mg/mL Vial [Vabysmo] 	6 mg
+50242-0096-86:	76f0nrg -> wxyhwvz	0.05 mL faricimab-svoa 120 mg/mL Vial [Vabysmo] 	6 mg
+00002-1433-61:	78ztkx7 -> 4w175dk	0.5 mL dulaglutide 1.5 mg/mL Auto-Injector [Trulicity] 	0.75 mg
+00002-1433-80:	78ztkx7 -> 4w175dk	0.5 mL dulaglutide 1.5 mg/mL Auto-Injector [Trulicity] 	0.75 mg
+50090-3484-00:	78ztkx7 -> 4w175dk	0.5 mL dulaglutide 1.5 mg/mL Auto-Injector [Trulicity] 	0.75 mg
+50090-6453-00:	78ztkx7 -> 4w175dk	0.5 mL dulaglutide 1.5 mg/mL Auto-Injector [Trulicity] 	0.75 mg
+58160-0812-52:	7b9pgmn -> d5n5cgx	0.5 mL acellular pertussis vaccine, inactivated 0.116 mg/mL / diphtheria toxoid vaccine, inactivated 50 UNT/mL / poliovirus vaccine inactivated, type 1 (Mahoney) 80 UNT/mL / poliovirus vaccine inactivated, type 2 (MEF-1) 16 UNT/mL / poliovirus vaccine inactivated, type 3 (Saukett) 64 UNT/mL / tetanus toxoid vaccine, inactivated 20 UNT/mL Prefilled Syringe [Kinrix] 	25; 0.01; 0.03; 10; 25; 40; 8; 32 [IU]; mg; mg; [IU]; [IU]; [IU]; [IU]; [IU]
+49281-0562-10:	7c5amxs -> 6r01e12	0.5 mL Bordetella pertussis filamentous hemagglutinin vaccine, inactivated 0.05 mg/mL / Bordetella pertussis pertactin vaccine, inactivated 0.016 mg/mL / Bordetella pertussis toxoid vaccine, inactivated 0.05 mg/mL / diphtheria toxoid vaccine, inactivated 50 UNT/mL / poliovirus vaccine inactivated, type 1 (Mahoney) 80 UNT/mL / poliovirus vaccine inactivated, type 2 (MEF-1) 16 UNT/mL / poliovirus vaccine inactivated, type 3 (Saukett) 64 UNT/mL / tetanus toxoid vaccine, inactivated 20 UNT/mL Vial [Kinrix] 	0.02; 0.01; 0; 0.02; 5; 15; 40; 8; 32 mg; mg; mg; mg; [LF]; [LF]; [D'AG'U]; [D'AG'U]; [D'AG'U]
+69448-0014-63:	7chh2nh -> d41m74s	Leuprolide 42 mg Prefilled Syringe [Camcevi] 	42 mg
+55513-0209-10:	7ckwmgv -> teaqm3y	0.8 mL filgrastim 0.6 mg/mL Prefilled Syringe [Neupogen] 	0.48 mg
+55513-0209-91:	7ckwmgv -> teaqm3y	0.8 mL filgrastim 0.6 mg/mL Prefilled Syringe [Neupogen] 	0.48 mg
+72065-0130-11:	7cv39ss -> pybztvk	0.1 mL glucagon 5 mg/mL Prefilled Syringe [Gvoke] 	0.5 mg
+72065-0130-12:	7cv39ss -> pybztvk	0.1 mL glucagon 5 mg/mL Prefilled Syringe [Gvoke] 	0.5 mg
+72065-0130-99:	7cv39ss -> pybztvk	0.1 mL glucagon 5 mg/mL Prefilled Syringe [Gvoke] 	0.5 mg
+72065-0131-11:	7cv39ss -> ek859fr	0.2 mL glucagon 5 mg/mL Prefilled Syringe [Gvoke] 	1 mg
+72065-0131-12:	7cv39ss -> ek859fr	0.2 mL glucagon 5 mg/mL Prefilled Syringe [Gvoke] 	1 mg
+72065-0131-99:	7cv39ss -> ek859fr	0.2 mL glucagon 5 mg/mL Prefilled Syringe [Gvoke] 	1 mg
+72065-0120-11:	7gkddev -> s2mymns	0.1 mL glucagon 5 mg/mL Auto-Injector [Gvoke] 	0.5 mg
+72065-0120-12:	7gkddev -> s2mymns	0.1 mL glucagon 5 mg/mL Auto-Injector [Gvoke] 	0.5 mg
+63459-0910-11:	7jmjent -> 8p0cq3j	0.5 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.3 mg
+63459-0910-15:	7jmjent -> 8p0cq3j	0.5 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.3 mg
+63459-0910-17:	7jmjent -> 8p0cq3j	0.5 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.3 mg
+63459-0910-36:	7jmjent -> 8p0cq3j	0.5 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.3 mg
+69097-0709-96:	7k45wdt -> gy9k5x2	0.5 mL vitamin K1 2 mg/mL Prefilled Syringe 	1 mg
+55513-0221-01:	7kgsw3z -> ek0kq6r	Romiplostim 0.25 mg Vial [Nplate] 	0.25 mg
+00409-9157-01:	7njnmc9 -> 13fgdec	0.5 mL vitamin K1 2 mg/mL Prefilled Syringe 	1 mg
+64406-0011-01:	7w432xa -> y0dy2q5	0.5 mL peginterferon beta-1a 0.25 mg/mL Auto-Injector [Plegridy] 	0.12 mg
+60842-0022-01:	84j7amj -> qyr5xbv	NDA201739 0.15 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.15 mg
+60842-0023-01:	84j7amj -> tzkemkg	NDA201739 0.3 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.3 mg
+55513-0411-01:	8771x1r -> cydnvr2	0.4 mL adalimumab-atto 50 mg/mL Prefilled Syringe [Amjevita] 	20 mg
+00024-5911-02:	8ep4vnb -> wn2r19r	0.67 mL dupilumab 150 mg/mL Prefilled Syringe [Dupixent] 	100 mg
+00024-5911-20:	8ep4vnb -> wn2r19r	0.67 mL dupilumab 150 mg/mL Prefilled Syringe [Dupixent] 	100 mg
+58160-0820-52:	8fsvsh1 -> k764k2v	0.5 mL hepatitis B surface antigen vaccine 0.02 mg/mL Prefilled Syringe [Engerix-B] 	0.01 mg
+00006-4171-00:	8g8zdxp -> 6wc9abs	0.5 mL measles virus vaccine live, Enders' attenuated Edmonston strain 2000 UNT/mL / mumps virus vaccine live, Jeryl Lynn strain 40000 UNT/mL / rubella virus vaccine live (Wistar RA 27-3 strain) 2000 UNT/mL / varicella-zoster virus vaccine live (Oka-Merck) strain 20000 UNT/mL Vial [ProQuad] 	1000; 20000; 1000; 9772 [TCID_50]; [TCID_50]; [TCID_50]; [PFU]
+68135-0058-90:	8jnk9j4 -> x505ben	0.5 mL pegvaliase-pqpz 5 mg/mL Prefilled Syringe [Palynziq] 	2.5 mg
+54436-0015-01:	8s9srkw -> 46q8grh	0.4 mL methotrexate 37.5 mg/mL Auto-Injector [Otrexup] 	15 mg
+54436-0015-03:	8s9srkw -> 46q8grh	0.4 mL methotrexate 37.5 mg/mL Auto-Injector [Otrexup] 	15 mg
+54436-0015-04:	8s9srkw -> 46q8grh	0.4 mL methotrexate 37.5 mg/mL Auto-Injector [Otrexup] 	15 mg
+51662-1320-02:	8v6bxce -> 37nawtg	NDA201739 0.3 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.3 mg
+61755-0005-02:	8w2acjy -> 120hcve	0.05 mL aflibercept 40 mg/mL Vial [Eylea] 	2 mg
+61755-0005-55:	8w2acjy -> 120hcve	0.05 mL aflibercept 40 mg/mL Vial [Eylea] 	2 mg
+00641-6249-10:	8xb7vn4 -> rz2d98v	0.5 mL fentanyl 0.05 mg/mL Prefilled Syringe 	0.03 mg
+63361-0243-10:	8yxcgva -> nsg6ea2	Diphtheria and tetanus toxoids and acellular pertussis, inactivated poliovirus, haemophilus b conjugate and hepatitis b vaccine 0.02; 0.01; 0.0; 0.02; 5.0; 15.0; 0.0; 0.01; 30.0; 7.0; 26 mg; mg; mg; mg; [LF]; [LF]; mg; mg; [D'AG'U]; [D'AG'U]; [D'AG'U] Vial [Vaxelis] 	0.02; 0.01; 0; 0.02; 5; 15; 0; 0.01; 30; 7; 26 mg; mg; mg; mg; [LF]; [LF]; mg; mg; [D'AG'U]; [D'AG'U]; [D'AG'U]
+54436-0250-01:	9bf0144 -> 403vsfd	0.5 mL testosterone enanthate 100 mg/mL Auto-Injector [Xyosted] 	50 mg
+54436-0250-04:	9bf0144 -> 403vsfd	0.5 mL testosterone enanthate 100 mg/mL Auto-Injector [Xyosted] 	50 mg
+00115-1694-30:	9cf93qy -> 5e9gfdj	Epinephrine 0.3 mg Syringe 	0.3 mg
+00115-1694-49:	9cf93qy -> 5e9gfdj	Epinephrine 0.3 mg Syringe 	0.3 mg
+42291-0425-02:	9cf93qy -> 5e9gfdj	Epinephrine 0.3 mg Syringe 	0.3 mg
+80425-0264-01:	9cf93qy -> 5e9gfdj	Epinephrine 0.3 mg Syringe 	0.3 mg
+62195-0051-01:	9hj2wvb -> nhyprk3	0.5 mL Japanese encephalitis virus vaccine Nakayama-NIH strain, inactivated 0.012 mg/mL Prefilled Syringe [Ixiaro] 	0.01 mg
+49281-0323-50:	9kftpc -> g25ph1k	0.5 mL influenza A virus A/Darwin/9/2021 (H3N2) antigen 0.03 mg/mL / influenza A virus A/Sydney/5/2021 (H1N1) antigen 0.03 mg/mL / influenza B virus B/Michigan/01/2021 antigen 0.03 mg/mL / influenza B virus B/Phuket/3073/2013 antigen 0.03 mg/mL Prefilled Syringe [Fluzone Quadrivalent 2023 Southern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+00169-4517-14:	9nchdsh -> x4k5kmj	0.75 mL semaglutide 2.27 mg/mL Auto-Injector [Wegovy] 	1.13 mg
+50242-0921-01:	9t05v05 -> 63fz3qd	0.4 mL emicizumab-kxwh 150 mg/mL Vial [Hemlibra] 	60 mg
+50242-0922-01:	9t05v05 -> qnptyez	0.7 mL emicizumab-kxwh 150 mg/mL Vial [Hemlibra] 	105 mg
+00002-2236-61:	a5x42az -> yd251gx	0.5 mL dulaglutide 6 mg/mL Auto-Injector [Trulicity] 	3 mg
+00002-2236-80:	a5x42az -> yd251gx	0.5 mL dulaglutide 6 mg/mL Auto-Injector [Trulicity] 	3 mg
+50090-5467-00:	a5x42az -> yd251gx	0.5 mL dulaglutide 6 mg/mL Auto-Injector [Trulicity] 	3 mg
+49281-0400-20:	aah6yaa -> bbdxs76	Clostridium tetani toxoid antigen (formaldehyde inactivated), corynebacterium diphtheriae toxoid antigen (formaldehyde inactivated), bordetella pertussis toxoid antigen (glutaraldehyde inactivated), bordetella pertussis filamentous hemagglutinin antigen (formaldehyde inactivated), bordetella pertussis pertactin antigen, and bordetella pertussis fimbriae 2/3 antigen 0.01; 0.01; 0.0; 0.0; 5.0; 2 mg; mg; mg; mg; [LF]; [LF] Syringe [Adacel] 	0.01; 0.01; 0; 0; 5; 2 mg; mg; mg; mg; [LF]; [LF]
+57894-0060-02:	abyxet0 -> tbtrerq	Ustekinumab 45 mg Vial [Stelara] 	45 mg
+63361-0243-15:	am4mkhb -> za47ees	Diphtheria and tetanus toxoids and acellular pertussis, inactivated poliovirus, haemophilus b conjugate and hepatitis b vaccine 0.02; 0.01; 0.0; 0.02; 5.0; 15.0; 0.0; 0.01; 30.0; 7.0; 26 mg; mg; mg; mg; [LF]; [LF]; mg; mg; [D'AG'U]; [D'AG'U]; [D'AG'U] Syringe [Vaxelis] 	0.02; 0.01; 0; 0.02; 5; 15; 0; 0.01; 30; 7; 26 mg; mg; mg; mg; [LF]; [LF]; mg; mg; [D'AG'U]; [D'AG'U]; [D'AG'U]
+54436-0012-01:	ar051dg -> gw5m7gk	0.4 mL methotrexate 31.3 mg/mL Auto-Injector [Otrexup] 	12.5 mg
+54436-0012-03:	ar051dg -> gw5m7gk	0.4 mL methotrexate 31.3 mg/mL Auto-Injector [Otrexup] 	12.5 mg
+54436-0012-04:	ar051dg -> gw5m7gk	0.4 mL methotrexate 31.3 mg/mL Auto-Injector [Otrexup] 	12.5 mg
+70121-1568-01:	ar3tap5 -> 3hmk86v	0.5 mL filgrastim-ayow 0.6 mg/mL Prefilled Syringe [Releuko] 	0.3 mg
+70121-1568-07:	ar3tap5 -> 3hmk86v	0.5 mL filgrastim-ayow 0.6 mg/mL Prefilled Syringe [Releuko] 	0.3 mg
+58160-0842-52:	av1qrw2 -> f0p32f1	Tetanus toxoid, reduced diphtheria toxoid and acellular pertussis vaccine, adsorbed 0.01; 0.0; 0.01; 5.0; 2.5 mg; mg; mg; [IU]; [IU] Syringe [Boostrix] 	0.01; 0; 0.01; 5; 2.5 mg; mg; mg; [IU]; [IU]
+00006-4681-00:	avr0zyt -> 92a5ydn	0.5 mL measles virus vaccine live, Enders' attenuated Edmonston strain 2000 UNT/mL / mumps virus vaccine live, Jeryl Lynn strain 25000 UNT/mL / rubella virus vaccine live (Wistar RA 27-3 strain) 2000 UNT/mL Vial [M-M-R II] 	1000; 12500; 1000 [TCID_50]; [TCID_50]; [TCID_50]
+50090-1860-00:	avr0zyt -> 92a5ydn	0.5 mL measles virus vaccine live, Enders' attenuated Edmonston strain 2000 UNT/mL / mumps virus vaccine live, Jeryl Lynn strain 25000 UNT/mL / rubella virus vaccine live (Wistar RA 27-3 strain) 2000 UNT/mL Vial [M-M-R II] 	1000; 12500; 1000 [TCID_50]; [TCID_50]; [TCID_50]
+50090-6428-00:	avygxh9 -> 19sh7dy	0.8 mL adalimumab-atto 50 mg/mL Auto-Injector [Amjevita] 	40 mg
+55513-0400-01:	avygxh9 -> 19sh7dy	0.8 mL adalimumab-atto 50 mg/mL Auto-Injector [Amjevita] 	40 mg
+55513-0400-02:	avygxh9 -> 19sh7dy	0.8 mL adalimumab-atto 50 mg/mL Auto-Injector [Amjevita] 	40 mg
+55513-0400-91:	avygxh9 -> 19sh7dy	0.8 mL adalimumab-atto 50 mg/mL Auto-Injector [Amjevita] 	40 mg
+72511-0400-01:	avygxh9 -> 19sh7dy	0.8 mL adalimumab-atto 50 mg/mL Auto-Injector [Amjevita] 	40 mg
+72511-0400-02:	avygxh9 -> 19sh7dy	0.8 mL adalimumab-atto 50 mg/mL Auto-Injector [Amjevita] 	40 mg
+49281-0422-10:	bd7mqt2 -> s96sy8t	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/darwin/9/2021 san-010 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), and influenza b virus b/michigan/01/2021 antigen (formaldehyde inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Vial [Fluzone Quadrivalent Northern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+00093-5986-27:	be0hk39 -> mzj97n5	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+49502-0102-02:	be0hk39 -> mzj97n5	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+49502-0500-02:	be0hk39 -> mzj97n5	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+70518-2283-00:	be0hk39 -> mzj97n5	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+71872-7135-01:	be0hk39 -> mzj97n5	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+76420-0188-02:	be0hk39 -> mzj97n5	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+50242-0080-03:	bh8e5hn -> kn00ve7	0.05 mL ranibizumab 10 mg/mL Prefilled Syringe [Lucentis] 	0.5 mg
+50242-0080-88:	bh8e5hn -> kn00ve7	0.05 mL ranibizumab 10 mg/mL Prefilled Syringe [Lucentis] 	0.5 mg
+55513-0192-01:	bjqf5x0 -> 7y9h0py	0.6 mL pegfilgrastim 10 mg/mL Syringe [Neulasta] 	0.6 mL
+00069-0292-01:	bq0pe6b -> 85964c3	0.8 mL filgrastim-aafi 0.6 mg/mL Prefilled Syringe [Nivestym] 	0.48 mg
+00069-0292-10:	bq0pe6b -> 85964c3	0.8 mL filgrastim-aafi 0.6 mg/mL Prefilled Syringe [Nivestym] 	0.48 mg
+49281-0519-25:	brxkz02 -> ads82g9	0.25 mL influenza A virus A/Brisbane/02/2018 (H1N1) antigen 0.03 mg/mL / influenza A virus A/Kansas/14/2017 (H3N2) antigen 0.03 mg/mL / influenza B virus B/Maryland/15/2016 antigen 0.03 mg/mL / influenza B virus B/Phuket/3073/2013 antigen 0.03 mg/mL Prefilled Syringe [Fluzone Quadrivalent 2019-2020] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+49471-0001-05:	c2jcxkk -> x3w5n2n	Benzylpenicilloyl polylysine 60 UMOL Ampule [Pre-Pen] 	60 UMOL
+00173-0904-42:	c8tfrzz -> epd7509	0.4 mL mepolizumab 100 mg/mL Prefilled Syringe [Nucala] 	40 mg
+49281-0589-05:	cbhyd2j -> qw43kpf	0.5 mL Neisseria meningitidis serogroup A capsular polysaccharide diphtheria toxoid protein conjugate vaccine 0.104 mg/mL / Neisseria meningitidis serogroup C capsular polysaccharide diphtheria toxoid protein conjugate vaccine 0.104 mg/mL / Neisseria meningitidis serogroup W-135 capsular polysaccharide diphtheria toxoid protein conjugate vaccine 0.104 mg/mL / Neisseria meningitidis serogroup Y capsular polysaccharide diphtheria toxoid protein conjugate vaccine 0.104 mg/mL Vial [Menactra] 	0; 0; 0; 0 mg; mg; mg; mg
+25682-0019-12:	czm6hbc -> 6bkg4zk	0.8 mL asfotase alfa 100 mg/mL Vial [Strensiq] 	80 mg
+00009-4709-13:	d38st5g -> awxmenn	0.65 mL medroxyprogesterone acetate 160 mg/mL Prefilled Syringe [depo-subQ provera] 	104 mg
+66658-0230-01:	dctt691 -> f5b070m	0.5 mL palivizumab 100 mg/mL Vial [Synagis] 	50 mg
+49281-0421-10:	dd0v376 -> 72dyd86	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/tasmania/503/2020 ivr-221 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), influenza b virus b/washington/02/2019 antigen (formaldehyde inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Vial [Fluzone Quadrivalent Northern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+82705-0002-01:	dftx7s7 -> 9zv0w7q	0.8 mL epcoritamab-bysp 5 mg/mL Vial [Epkinly] 	4 mg
+70114-0101-01:	dgvfgxz -> d32g5hc	Pegfilgrastim-cbqv 6 mg Syringe [Udenyca] 	6 mg
+70114-0120-01:	dgvfgxz -> d32g5hc	Pegfilgrastim-cbqv 6 mg Syringe [Udenyca] 	6 mg
+50242-0214-01:	dhqx2vw -> y9qdcxz	0.5 mL omalizumab 150 mg/mL Prefilled Syringe [Xolair] 	75 mg
+50242-0214-86:	dhqx2vw -> y9qdcxz	0.5 mL omalizumab 150 mg/mL Prefilled Syringe [Xolair] 	75 mg
+59627-0222-05:	djapket -> 59e1t6n	0.5 mL interferon beta-1a 0.06 mg/mL Prefilled Syringe [Avonex] 	0.4 mL
+54436-0020-01:	dpbcff2 -> tagd64n	0.4 mL methotrexate 50 mg/mL Auto-Injector [Otrexup] 	20 mg
+54436-0020-03:	dpbcff2 -> tagd64n	0.4 mL methotrexate 50 mg/mL Auto-Injector [Otrexup] 	20 mg
+54436-0020-04:	dpbcff2 -> tagd64n	0.4 mL methotrexate 50 mg/mL Auto-Injector [Otrexup] 	20 mg
+49281-0564-15:	drfcqvr -> 59garvn	Diphtheria and tetanus toxoids and acellular pertussis adsorbed and inactivated poliovirus vaccine 0.02; 0.01; 0.0; 0.02; 5.0; 15.0; 30.0; 7.0; 26 mg; mg; mg; mg; [LF]; [LF]; [D'AG'U]; [D'AG'U]; [D'AG'U] Syringe [Quadracel] 	0.02; 0.01; 0; 0.02; 5; 15; 30; 7; 26 mg; mg; mg; mg; [LF]; [LF]; [D'AG'U]; [D'AG'U]; [D'AG'U]
+58406-0055-04:	dvyyejg -> hehbkvy	0.5 mL etanercept 50 mg/mL Vial [Enbrel] 	25 mg
+58406-0055-96:	dvyyejg -> hehbkvy	0.5 mL etanercept 50 mg/mL Vial [Enbrel] 	25 mg
+68875-0102-01:	dwfsaew -> enm9hsh	Teduglutide 5 mg Vial [Gattex] 	0.5 mL
+68875-0103-01:	dwfsaew -> enm9hsh	Teduglutide 5 mg Vial [Gattex] 	0.5 mL
+11704-0105-01:	dyf61ng -> epgctwm	0.7 mL atropine sulfate 1.43 mg/mL Auto-Injector [Atropen] 	1 mg
+25682-0010-12:	e86jv8v -> t9trxxw	0.45 mL asfotase alfa 40 mg/mL Vial [Strensiq] 	18 mg
+00143-9638-25:	efce9nn -> tqvh22s	0.5 mL sumatriptan 12 mg/mL Vial [Imitrex] 	6 mg
+36000-0289-05:	efce9nn -> tqvh22s	0.5 mL sumatriptan 12 mg/mL Vial [Imitrex] 	6 mg
+36000-0289-10:	efce9nn -> tqvh22s	0.5 mL sumatriptan 12 mg/mL Vial [Imitrex] 	6 mg
+36000-0289-25:	efce9nn -> tqvh22s	0.5 mL sumatriptan 12 mg/mL Vial [Imitrex] 	6 mg
+65145-0118-05:	efce9nn -> tqvh22s	0.5 mL sumatriptan 12 mg/mL Vial [Imitrex] 	6 mg
+00006-4045-00:	eh0h49t -> 2yrx0h5	Human papillomavirus quadrivalent (types 6, 11, 16, and 18) vaccine, recombinant 0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg Vial [Gardasil] 	0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg
+00006-4045-41:	eh0h49t -> 2yrx0h5	Human papillomavirus quadrivalent (types 6, 11, 16, and 18) vaccine, recombinant 0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg Vial [Gardasil] 	0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg
+58160-0827-30:	epgmqmg -> 2mtdkgd	0.5 mL Neisseria meningitidis serogroup A oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup C oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.01 mg/mL / Neisseria meningitidis serogroup W-135 oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.01 mg/mL / Neisseria meningitidis serogroup Y oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.01 mg/mL Vial [Menveo] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+00006-4119-03:	epz1vgj -> f173pph	Human papillomavirus 9-valent vaccine, recombinant 0.04; 0.06; 0.04; 0.02; 0.02; 0.02; 0.02; 0.02; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg Vial [Gardasil 9] 	0.04; 0.06; 0.04; 0.02; 0.02; 0.02; 0.02; 0.02; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg
+00006-4831-41:	esaf0vz -> k5wpwy6	Hepatitis a vaccine, inactivated 25 [IU] Vial [Vaqta] 	25 [IU]
+51662-1476-01:	ev32832 -> h7enf1a	NDA201739 0.1 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.1 mg
+60842-0021-01:	ev32832 -> h7enf1a	NDA201739 0.1 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.1 mg
+00548-5001-00:	evkcpcz -> ve03knr	0.5 mL ganirelix acetate 0.5 mg/mL Prefilled Syringe [Antagon] 	0.25 mg
+55566-1000-01:	evkcpcz -> ve03knr	0.5 mL ganirelix acetate 0.5 mg/mL Prefilled Syringe [Antagon] 	0.25 mg
+55566-1010-01:	evkcpcz -> ve03knr	0.5 mL ganirelix acetate 0.5 mg/mL Prefilled Syringe [Antagon] 	0.25 mg
+71288-0554-80:	evkcpcz -> ve03knr	0.5 mL ganirelix acetate 0.5 mg/mL Prefilled Syringe [Antagon] 	0.25 mg
+00006-4121-02:	f77wghg -> 5bsm6d7	0.5 mL L1 protein, human papillomavirus type 11 vaccine 0.08 mg/mL / L1 protein, human papillomavirus type 16 vaccine 0.12 mg/mL / L1 protein, human papillomavirus type 18 vaccine 0.08 mg/mL / L1 protein, human papillomavirus type 31 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 33 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 45 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 52 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 58 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 6 vaccine 0.06 mg/mL Prefilled Syringe [Gardasil 9] 	0.04; 0.06; 0.04; 0.02; 0.02; 0.02; 0.02; 0.02; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg
+50090-4958-01:	f77wghg -> 5bsm6d7	0.5 mL L1 protein, human papillomavirus type 11 vaccine 0.08 mg/mL / L1 protein, human papillomavirus type 16 vaccine 0.12 mg/mL / L1 protein, human papillomavirus type 18 vaccine 0.08 mg/mL / L1 protein, human papillomavirus type 31 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 33 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 45 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 52 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 58 vaccine 0.04 mg/mL / L1 protein, human papillomavirus type 6 vaccine 0.06 mg/mL Prefilled Syringe [Gardasil 9] 	0.04; 0.06; 0.04; 0.02; 0.02; 0.02; 0.02; 0.02; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg
+00169-4501-14:	fa2pwd8 -> g66v7wh	0.5 mL semaglutide 2 mg/mL Auto-Injector [Wegovy] 	1 mg
+58160-0811-52:	fafs69x -> skb97yw	0.5 mL acellular pertussis vaccine, inactivated 0.116 mg/mL / diphtheria toxoid vaccine, inactivated 50 UNT/mL / hepatitis B surface antigen vaccine 0.02 mg/mL / poliovirus vaccine inactivated, type 1 (Mahoney) 80 UNT/mL / poliovirus vaccine inactivated, type 2 (MEF-1) 16 UNT/mL / poliovirus vaccine inactivated, type 3 (Saukett) 64 UNT/mL / tetanus toxoid vaccine, inactivated 20 UNT/mL Prefilled Syringe [PEDIARIX] 	0.03; 0.01; 0.03; 10; 25; 0.01; 40; 8; 32 mg; mg; mg; [IU]; [IU]; mg; [IU]; [IU]; [IU]
+00781-3443-12:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+00781-3443-95:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+11797-0154-06:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+11797-0154-09:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+43598-0607-02:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+43598-0607-10:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+55111-0678-02:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+55111-0678-10:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+55150-0230-02:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+55150-0230-10:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+67457-0582-10:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+67457-0592-10:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+70710-1514-06:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+70710-1514-09:	fb4ahzw -> s6f46j8	0.5 mL fondaparinux sodium 5 mg/mL Prefilled Syringe [Arixtra] 	2.5 mg
+49281-0215-15:	fg6kf2d -> y3g6g97	Clostridium tetani toxoid antigen (formaldehyde inactivated) and corynebacterium diphtheriae toxoid antigen (formaldehyde inactivated) 5.0; 2 [LF]; [LF] Syringe [Tenivac] 	5; 2 [LF]; [LF]
+00005-1971-02:	fjr0s1v -> c450tze	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0088 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL Prefilled Syringe [Prevnar 13] 	0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+00005-1971-05:	fjr0s1v -> c450tze	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0088 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.0044 mg/mL Prefilled Syringe [Prevnar 13] 	0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+54436-0200-01:	fnqs09k -> rbg2bh2	0.5 mL testosterone enanthate 200 mg/mL Auto-Injector [Xyosted] 	100 mg
+54436-0200-04:	fnqs09k -> rbg2bh2	0.5 mL testosterone enanthate 200 mg/mL Auto-Injector [Xyosted] 	100 mg
+64406-0019-01:	fr6mys5 -> 2gbw3fs	0.05 mL ranibizumab-nuna 10 mg/mL Vial [Byooviz] 	0.5 mg
+64406-0019-08:	fr6mys5 -> 2gbw3fs	0.05 mL ranibizumab-nuna 10 mg/mL Vial [Byooviz] 	0.5 mg
+55513-0021-04:	fs91czj -> b3k9j6n	0.4 mL darbepoetin alfa 0.1 mg/mL Prefilled Syringe [Aranesp] 	0.04 mg
+71336-1003-01:	fvp1hv4 -> e6gvcym	0.5 mL vutrisiran 50 mg/mL Prefilled Syringe [Amvuttra] 	25 mg
+43528-0003-05:	fw36x3a -> b7rj5r2	0.5 mL hepatitis B surface antigen vaccine 0.04 mg/mL Syringe [Heplisav-B] 	0.02 mg
+44087-3322-01:	g23v5nz -> yk2wkn4	0.5 mL interferon beta-1a 0.044 mg/mL Auto-Injector [Rebif] 	0.02 mg
+67457-0833-06:	g2981rc -> y24be0a	0.6 mL pegfilgrastim-jmdb 10 mg/mL Prefilled Syringe [Fulphila] 	6 mg
+51662-1320-01:	g5fcxf9 -> 37nawtg	NDA201739 0.3 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.3 mg
+59627-0333-04:	ge48dra -> xe9b5yr	0.5 mL interferon beta-1a 0.06 mg/mL Auto-Injector [Avonex] 	0.4 mL
+00143-9638-05:	gjha0cs -> abzv7jh	Sumatriptan 6 mg Vial 	6 mg
+55150-0173-01:	gjha0cs -> abzv7jh	Sumatriptan 6 mg Vial 	6 mg
+55150-0173-05:	gjha0cs -> abzv7jh	Sumatriptan 6 mg Vial 	6 mg
+60429-0995-05:	gjha0cs -> abzv7jh	Sumatriptan 6 mg Vial 	6 mg
+63323-0273-01:	gjha0cs -> abzv7jh	Sumatriptan succinate 6 mg Vial 	6 mg
+70069-0804-01:	gjha0cs -> abzv7jh	Sumatriptan 6 mg Vial 	6 mg
+70069-0804-05:	gjha0cs -> abzv7jh	Sumatriptan 6 mg Vial 	6 mg
+70594-0068-02:	gjha0cs -> abzv7jh	Sumatriptan succinate 6 mg Vial [Sumatriptan] 	6 mg
+71205-0111-01:	gjha0cs -> efce9nn	0.5 mL sumatriptan 12 mg/mL Vial [Imitrex] 	12 mg
+62935-0461-50:	gpsfvb6 -> 575s8p1	0.375 mL leuprolide acetate 120 mg/mL Prefilled Syringe [Eligard] 	45 mg
+57894-0060-03:	gy1kez4 -> 4grza38	Ustekinumab 45 mg Syringe [Stelara] 	45 mg
+57894-0060-04:	gy1kez4 -> 4grza38	Ustekinumab 45 mg Syringe [Stelara] 	45 mg
+57894-0061-03:	gy1kez4 -> d7564dy	1 mL ustekinumab 90 mg/mL Prefilled Syringe [Stelara] 	90 mg
+57894-0061-04:	gy1kez4 -> d7564dy	1 mL ustekinumab 90 mg/mL Prefilled Syringe [Stelara] 	90 mg
+49281-0120-65:	h4qsdm8 -> tskca8n	Influenza a virus a/guangdong-maonan/swl1536/2019 cnic-1909 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/hong kong/2671/2019 ivr-208 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), influenza b virus b/washington/02/2019 antigen (formaldehyde inactivated) 0.06; 0.06; 0.06; 0.06 mg; mg; mg; mg Syringe [Fluzone High-Dose Quadrivalent Northern Hemisphere] 	0.06; 0.06; 0.06; 0.06 mg; mg; mg; mg
+49281-0121-65:	h4qsdm8 -> tskca8n	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/tasmania/503/2020 ivr-221 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), influenza b virus b/washington/02/2019 antigen (formaldehyde inactivated) 0.06; 0.06; 0.06; 0.06 mg; mg; mg; mg Syringe [Fluzone High-Dose Quadrivalent Northern Hemisphere] 	0.06; 0.06; 0.06; 0.06 mg; mg; mg; mg
+49281-0122-65:	h4qsdm8 -> tskca8n	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/darwin/9/2021 san-010 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), and influenza b virus b/michigan/01/2021 antigen (formaldehyde inactivated) 0.06; 0.06; 0.06; 0.06 mg; mg; mg; mg Syringe [Fluzone High-Dose Quadrivalent Northern Hemisphere] 	0.06; 0.06; 0.06; 0.06 mg; mg; mg; mg
+00006-4837-03:	h9aqzrn -> mffd8kj	Pneumococcal vaccine polyvalent 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg Syringe [Pneumovax 23] 	0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03; 0.03 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+50090-3372-00:	h9jppa9 -> a0q4ekc	0.5 mL varicella zoster virus glycoprotein E, recombinant 0.1 mg/mL Vial [Shingrix] 	0.5 mL
+58160-0819-12:	h9jppa9 -> a0q4ekc	0.5 mL varicella zoster virus glycoprotein E, recombinant 0.1 mg/mL Vial [Shingrix] 	0.5 mL
+58160-0823-11:	h9jppa9 -> a0q4ekc	0.5 mL varicella zoster virus glycoprotein E, recombinant 0.1 mg/mL Vial [Shingrix] 	0.5 mL
+50242-0082-01:	hepbbd3 -> bbz8yy1	Ranibizumab 0.3 mg Vial [Lucentis] 	0.3 mg
+50242-0082-02:	hepbbd3 -> bbz8yy1	Ranibizumab 0.3 mg Vial [Lucentis] 	0.3 mg
+50242-0082-87:	hepbbd3 -> bbz8yy1	Ranibizumab 0.3 mg Vial [Lucentis] 	0.3 mg
+49281-0564-10:	hjtsqsm -> angz5g0	Diphtheria and tetanus toxoids and acellular pertussis adsorbed and inactivated poliovirus vaccine 0.02; 0.01; 0.0; 0.02; 5.0; 15.0; 30.0; 7.0; 26 mg; mg; mg; mg; [LF]; [LF]; [D'AG'U]; [D'AG'U]; [D'AG'U] Vial [Quadracel] 	0.02; 0.01; 0; 0.02; 5; 15; 30; 7; 26 mg; mg; mg; mg; [LF]; [LF]; [D'AG'U]; [D'AG'U]; [D'AG'U]
+00069-0195-02:	hkxk4an -> 817beqy	0.2 mL dalteparin sodium 12500 UNT/mL Prefilled Syringe [Fragmin] 	2500 [IU]
+71336-1002-01:	hrch4n7 -> w5hqnpx	0.5 mL lumasiran 189 mg/mL Vial [Oxlumo] 	94.5 mg
+00004-0357-30:	hvars39 -> e7v4w2c	0.5 mL peginterferon alfa-2a 0.36 mg/mL Prefilled Syringe [Pegasys] 	0.18 mg
+82154-0451-04:	hvars39 -> e7v4w2c	0.5 mL peginterferon alfa-2a 0.36 mg/mL Prefilled Syringe [Pegasys] 	0.18 mg
+66220-0812-22:	j54qwgq -> 2rpka44	0.5 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	12.5 mg
+66220-0815-22:	j54qwgq -> bj660a7	0.6 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	15 mg
+66220-0817-22:	j54qwgq -> dxs932n	0.7 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	17.5 mg
+66220-0820-22:	j54qwgq -> 5g9kffv	0.8 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	20 mg
+66220-0820-33:	j54qwgq -> q4ywvax	Methotrexate 20 mg Syringe [Reditrex] 	20 mg
+66220-0822-22:	j54qwgq -> kzrgqpe	0.9 mL methotrexate 25 mg/mL Prefilled Syringe [Reditrex] 	22.5 mg
+49281-0790-51:	j5bkpdy -> ax40zv7	Salmonella typhi ty2 vi polysaccharide antigen 0.03 mg Syringe [Typhim Vi] 	0.03 mg
+50090-1493-00:	j5bkpdy -> ax40zv7	Salmonella typhi ty2 vi polysaccharide antigen 0.03 mg Syringe [Typhim Vi] 	0.03 mg
+50090-6411-00:	jcyr74x -> s7sshrv	0.8 mL adalimumab-atto 50 mg/mL Prefilled Syringe [Amjevita] 	40 mg
+55513-0410-01:	jcyr74x -> s7sshrv	0.8 mL adalimumab-atto 50 mg/mL Prefilled Syringe [Amjevita] 	40 mg
+55513-0410-02:	jcyr74x -> s7sshrv	0.8 mL adalimumab-atto 50 mg/mL Prefilled Syringe [Amjevita] 	40 mg
+13533-0636-03:	je5y6bk -> cbeqvtz	0.5 mL hepatitis B immune globulin 220 UNT/mL Prefilled Syringe [Hyperhep B] 	110 [IU]
+00404-9935-05:	jk8mjq6 -> snfs78q	0.5 mL vitamin K1 2 mg/mL Prefilled Syringe 	1 mg
+52584-0046-01:	jk8mjq6 -> snfs78q	Phytonadione 1 mg Syringe 	1 mg
+76329-1240-01:	jk8mjq6 -> snfs78q	0.5 mL vitamin K1 2 mg/mL Prefilled Syringe 	1 mg
+71879-0001-01:	jkwxn7z -> bm1j01z	0.005 mL dexamethasone 103.4 mg/mL Vial [Dexycu] 	51.7 mg
+71665-0330-02:	jq0pj65 -> 5qw6y4a	Smallpox vaccine live, New York City Board of Health vaccinia strain 500000000 UNT/mL Vial [ACAM2000] 	30000000 [PFU]
+44087-1116-01:	jvcg53d -> 6e0d8j9	0.75 mL follitropin alfa 600 UNT/mL Pen Injector [Gonal F] 	450 [IU]
+19515-0808-52:	jxmfzce -> d9v8gex	Influenza virus vaccine 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Flulaval Quadrivalent] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+33332-0322-03:	jxmfzce -> d9v8gex	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (propiolactone inactivated), influenza a virus a/darwin/6/2021 ivr-227 (h3n2) antigen (propiolactone inactivated), influenza b virus b/austria/1359417/2021 bvr-26 antigen (propiolactone inactivated), influenza b virus b/phuket/3073/2013 bvr-1b antigen (propiolactone inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Afluria Quadrivalent] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+49281-0418-50:	jxmfzce -> d9v8gex	Influenza a virus a/michigan/45/2015 x-275 (h1n1) hemagglutinin antigen (formaldehyde inactivated), influenza a virus a/singapore/infimh-16-0019/2016 ivr-186 (h3n2) hemagglutinin antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 hemagglutinin antigen (formaldehyde inactivated), influenza b virus b/maryland/15/2016 bx-69a antigen (formaldehyde inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Fluzone Quadrivalent Northern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+49281-0420-50:	jxmfzce -> d9v8gex	Influenza a virus a/guangdong-maonan/swl1536/2019 cnic-1909 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/hong kong/2671/2019 ivr-208 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), influenza b virus b/washington/02/2019 antigen (formaldehyde inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Fluzone Quadrivalent Northern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+49281-0421-50:	jxmfzce -> d9v8gex	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/tasmania/503/2020 ivr-221 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), influenza b virus b/washington/02/2019 antigen (formaldehyde inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Fluzone Quadrivalent Northern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+49281-0422-50:	jxmfzce -> d9v8gex	Influenza a virus a/victoria/2570/2019 ivr-215 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/darwin/9/2021 san-010 (h3n2) antigen (formaldehyde inactivated), influenza b virus b/phuket/3073/2013 antigen (formaldehyde inactivated), and influenza b virus b/michigan/01/2021 antigen (formaldehyde inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Fluzone Quadrivalent Northern Hemisphere] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+58160-0890-52:	jxmfzce -> d9v8gex	Influenza virus vaccine 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Fluarix Quadrivalent] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+70461-0322-03:	jxmfzce -> d9v8gex	Influenza a virus a/delaware/55/2019 cvr-45 (h1n1) antigen (mdck cell derived, propiolactone inactivated), influenza a virus a/darwin/11/2021 (h3n2) antigen (mdck cell derived, propiolactone inactivated), influenza b virus b/singapore/wuh4618/2021 antigen (mdck cell derived, propiolactone inactivated), influenza b virus b/singapore/inftt-16-0610/2016 antigen (mdck cell derived, propiolactone inactivated) 0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg Syringe [Flucelvax Quadrivalent] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+59137-0525-01:	k0w4gg2 -> j6dharq	0.35 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	17.5 mg
+59137-0525-04:	k0w4gg2 -> j6dharq	0.35 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	17.5 mg
+59137-0535-01:	k0w4gg2 -> zhmrbdp	0.45 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	22.5 mg
+59137-0535-04:	k0w4gg2 -> zhmrbdp	0.45 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	22.5 mg
+59137-0540-01:	k0w4gg2 -> zqr75f2	0.5 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	25 mg
+59137-0540-04:	k0w4gg2 -> zqr75f2	0.5 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	25 mg
+70121-1627-01:	k1wse70 -> rt5qtbp	0.6 mL pegfilgrastim-pbbk 10 mg/mL Prefilled Syringe [Fylnetra] 	6 mg
+80644-0012-01:	k41qakv -> 4n2708r	Dasiglucagon 0.6 mg Syringe [Zegalogue] 	0.6 mg
+80644-0012-02:	k41qakv -> 4n2708r	Dasiglucagon 0.6 mg Syringe [Zegalogue] 	0.6 mg
+80644-0013-01:	k41qakv -> 4n2708r	Dasiglucagon 0.6 mg Syringe [Zegalogue] 	0.6 mg
+80644-0013-02:	k41qakv -> 4n2708r	Dasiglucagon 0.6 mg Syringe [Zegalogue] 	0.6 mg
+62935-0163-60:	k6h47fn -> rg8bv1z	0.375 mL leuprolide acetate 120 mg/mL Prefilled Syringe [Fensolvi] 	45 mg
+00009-5181-01:	keb46bk -> ypzennq	0.5 mL alprostadil 0.02 mg/mL Prefilled Syringe [Caverject] 	0.01 mg
+63539-0121-11:	keb46bk -> ypzennq	0.5 mL alprostadil 0.02 mg/mL Prefilled Syringe [Caverject] 	0.01 mg
+00006-4826-00:	kmd0h1z -> m7gzcrk	0.5 mL varicella-zoster virus vaccine live (Oka-Merck) strain 2700 UNT/mL Vial [Varivax] 	1350 [PFU]
+00006-4827-00:	kmd0h1z -> m7gzcrk	0.5 mL varicella-zoster virus vaccine live (Oka-Merck) strain 2700 UNT/mL Vial [Varivax] 	1350 [PFU]
+00264-5705-10:	kqaqgz6 -> k5gdsb5	Heparin sodium 5000 [USP'U] Syringe 	5000 [USP'U]
+00641-6204-10:	kqaqgz6 -> k5gdsb5	Heparin sodium 5000 [USP'U] Syringe 	5000 [USP'U]
+63323-0118-05:	kqaqgz6 -> k5gdsb5	Heparin sodium 5000 [USP'U] Syringe 	5000 [USP'U]
+71288-0405-81:	kqaqgz6 -> k5gdsb5	Heparin sodium 5000 [USP'U] Syringe 	5000 [USP'U]
+49281-0915-01:	kwg0ak1 -> n3vqb1s	0.5 mL yellow fever virus strain 17D-204 live antigen 4000 UNT/mL Vial [YF-Vax] 	4.74 [PFU]
+51662-1321-01:	m7xfx5x -> 9c0r9kp	NDA201739 0.15 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.15 mg
+00006-4329-02:	mc8fz71 -> 264fe2b	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 22F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 33F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.008 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL Prefilled Syringe [Vaxneuvance] 	0.03; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+00006-4329-03:	mc8fz71 -> 264fe2b	0.5 mL Streptococcus pneumoniae serotype 1 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 14 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 18C capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 19A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 19F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 22F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 23F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 3 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 33F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 4 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 5 capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 6A capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 6B capsular antigen diphtheria CRM197 protein conjugate vaccine 0.008 mg/mL / Streptococcus pneumoniae serotype 7F capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL / Streptococcus pneumoniae serotype 9V capsular antigen diphtheria CRM197 protein conjugate vaccine 0.004 mg/mL Prefilled Syringe [Vaxneuvance] 	0.03; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0 mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg; mg
+00002-3182-61:	md04fmp -> d0fyd0r	0.5 mL dulaglutide 9 mg/mL Auto-Injector [Trulicity] 	4.5 mg
+00002-3182-80:	md04fmp -> d0fyd0r	0.5 mL dulaglutide 9 mg/mL Auto-Injector [Trulicity] 	4.5 mg
+80446-0401-01:	mkt0sar -> 65djvmj	0.5 mL tebentafusp-tebn 0.2 mg/mL Vial [Kimmtrak] 	0.1 mg
+49281-0545-03:	mtjcpgp -> wyegy8t	0.5 mL Haemophilus influenzae type b strain 1482, capsular polysaccharide inactivated tetanus toxoid conjugate vaccine 0.068 mg/mL Vial [ActHIB] 	0.6 mL
+58160-0818-11:	mtjcpgp -> yzb3pm8	0.5 mL Haemophilus influenzae type b strain 20752, capsular polysaccharide inactivated tetanus toxoid conjugate vaccine 0.07 mg/mL Vial [Hiberix] 	0.85 mL
+49281-0605-01:	mtyb2cq -> 8kpsmmp	Dengue virus live antigen, CYD serotype 1 100000 UNT / dengue virus live antigen, CYD serotype 2 100000 UNT / dengue virus live antigen, CYD serotype 3 100000 UNT / dengue virus live antigen, CYD serotype 4 100000 UNT Vial [Dengvaxia] 	0.5 mL
+00002-1484-80:	mzkgbpp -> 57h7nab	0.5 mL tirzepatide 15 mg/mL Auto-Injector [Mounjaro] 	7.5 mg
+62935-0223-05:	n16ytf2 -> gkwherm	0.375 mL leuprolide acetate 60 mg/mL Prefilled Syringe [Eligard] 	0.38 mL
+62935-0303-30:	n16ytf2 -> 6z6vdac	0.5 mL leuprolide acetate 60 mg/mL Prefilled Syringe [Eligard] 	0.5 mL
+62935-0753-75:	n16ytf2 -> hfhxgwk	0.25 mL leuprolide acetate 30 mg/mL Prefilled Syringe [Eligard] 	0.25 mL
+55513-0924-10:	n2gcd61 -> 21q0nge	0.5 mL filgrastim 0.6 mg/mL Prefilled Syringe [Neupogen] 	0.3 mg
+55513-0924-91:	n2gcd61 -> 21q0nge	0.5 mL filgrastim 0.6 mg/mL Prefilled Syringe [Neupogen] 	0.3 mg
+49281-0379-50:	n2vearc -> 8arwcmr	0.7 mL influenza A virus A/Darwin/9/2021 (H3N2) antigen 0.0857 mg/mL / influenza A virus A/Sydney/5/2021 (H1N1) antigen 0.0857 mg/mL / influenza B virus B/Michigan/01/2021 antigen 0.0857 mg/mL / influenza B virus B/Phuket/3073/2013 antigen 0.0857 mg/mL Prefilled Syringe [Fluzone Quadrivalent 2023 Southern Hemisphere] 	0.08; 0.08; 0.08; 0.08 mg; mg; mg; mg
+44087-1150-01:	n8thz2y -> dphz24x	0.5 mL choriogonadotropin alfa 0.5 mg/mL Prefilled Syringe [Ovidrel] 	0.25 mg
+44087-0022-03:	ndvzwd3 -> pvy856y	0.5 mL interferon beta-1a 0.044 mg/mL Prefilled Syringe [Rebif] 	0.02 mg
+50458-0562-01:	nf82mb9 -> 863v8q0	0.75 mL paliperidone palmitate 156 mg/mL Prefilled Syringe [Invega] 	117 mg
+00009-5182-01:	ngpgmxt -> keb46bk	0.5 mL alprostadil 0.04 mg/mL Prefilled Syringe [Caverject] 	0.02 mg
+63539-0221-21:	ngpgmxt -> keb46bk	0.5 mL alprostadil 0.04 mg/mL Prefilled Syringe [Caverject] 	0.02 mg
+00075-2912-01:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+00075-8022-10:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+00548-5606-00:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+00781-3298-68:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+00781-3612-68:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+00955-1012-10:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+11797-0762-06:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+16714-0056-10:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+60505-0796-00:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+60505-0796-04:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+63323-0609-90:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+63323-0609-98:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+63323-0655-99:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+68001-0462-42:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+70710-1762-06:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+71288-0411-81:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+71288-0437-92:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+71288-0437-94:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+81952-0132-28:	ngxkycs -> j8fsvc2	0.8 mL enoxaparin sodium 150 mg/mL Prefilled Syringe [Lovenox] 	120 mg
+47426-0101-06:	nkkks9g -> 2enp9sp	0.4 mL granisetron 25 mg/mL Prefilled Syringe [Sustol] 	10 mg
+50458-0561-01:	nx20af2 -> qepb2se	0.5 mL paliperidone palmitate 156 mg/mL Prefilled Syringe [Invega] 	78 mg
+49281-0912-05:	nxpfhex -> 4d0gvqq	Sodium chloride 5.4 mg Vial [Diluent] 	5.4 mg
+59627-0003-01:	p0tx3qc -> twc2206	0.5 mL interferon beta-1a 0.06 mg/mL Auto-Injector [Avonex] 	0.03 mg
+13533-0131-01:	p1cwhkc -> rk4tpcr	0.5 mL diphtheria toxoid vaccine, inactivated 4 UNT/mL / tetanus toxoid vaccine, inactivated 4 UNT/mL Vial [Tdvax] 	2; 2 [LF]; [LF]
+14362-0111-04:	p1cwhkc -> rk4tpcr	0.5 mL diphtheria toxoid vaccine, inactivated 4 UNT/mL / tetanus toxoid vaccine, inactivated 4 UNT/mL Vial [Tdvax] 	2; 2 [LF]; [LF]
+76961-0101-01:	p2htda1 -> fteev7b	0.6 mL eflapegrastim-xnst 22 mg/mL Prefilled Syringe [Rolvedon] 	13.2 mg
+71053-0595-01:	p9w3by6 -> px7hknn	0.7 mL midazolam 14.3 mg/mL Auto-Injector 	10 mg
+00002-1457-80:	pgwffx1 -> kvr52zj	0.5 mL tirzepatide 30 mg/mL Auto-Injector [Mounjaro] 	15 mg
+15054-1120-04:	pmqjqj7 -> 6p0mnqe	0.5 mL lanreotide 240 mg/mL Prefilled Syringe [Somatuline] 	120 mg
+69097-0870-67:	pmqjqj7 -> 6p0mnqe	0.5 mL lanreotide 240 mg/mL Prefilled Syringe [Somatuline] 	120 mg
+76282-0711-67:	pmqjqj7 -> 6p0mnqe	0.5 mL lanreotide 240 mg/mL Prefilled Syringe [Somatuline] 	120 mg
+70114-0441-01:	pskqc0x -> wwxdcrd	0.05 mL ranibizumab-eqrn 10 mg/mL Vial [Cimerli] 	0.5 mg
+00005-0100-02:	pt8gf62 -> 7v4g61b	0.5 mL Neisseria meningitidis serogroup B recombinant LP2086 A05 protein variant antigen 0.12 mg/mL / Neisseria meningitidis serogroup B recombinant LP2086 B01 protein variant antigen 0.12 mg/mL Prefilled Syringe [Trumenba] 	0.06; 0.06 mg; mg
+00005-0100-05:	pt8gf62 -> 7v4g61b	0.5 mL Neisseria meningitidis serogroup B recombinant LP2086 A05 protein variant antigen 0.12 mg/mL / Neisseria meningitidis serogroup B recombinant LP2086 B01 protein variant antigen 0.12 mg/mL Prefilled Syringe [Trumenba] 	0.06; 0.06 mg; mg
+00005-0100-10:	pt8gf62 -> 7v4g61b	0.5 mL Neisseria meningitidis serogroup B recombinant LP2086 A05 protein variant antigen 0.12 mg/mL / Neisseria meningitidis serogroup B recombinant LP2086 B01 protein variant antigen 0.12 mg/mL Prefilled Syringe [Trumenba] 	0.06; 0.06 mg; mg
+00169-4524-14:	pv0nhdy -> ep344dc	0.75 mL semaglutide 3.2 mg/mL Auto-Injector [Wegovy] 	1.6 mg
+59267-1404-02:	pwszmvt -> 64abw9y	0.3 mL SARS-CoV-2 (COVID-19) vaccine, mRNA-BNT162b2 0.05 mg/mL / SARS-CoV-2 (COVID-19) vaccine, mRNA-BNT162b2 OMICRON (BA.4/BA.5) 0.05 mg/mL Vial 	0.02; 0.02 mg; mg
+00069-0220-02:	q1bb3q8 -> ehfgvb3	0.5 mL dalteparin sodium 25000 UNT/mL Prefilled Syringe [Fragmin] 	12500 [IU]
+00069-0223-02:	q1bb3q8 -> 2y1b340	0.6 mL dalteparin sodium 25000 UNT/mL Prefilled Syringe [Fragmin] 	15000 [IU]
+00069-0228-02:	q1bb3q8 -> qdyr8xn	0.72 mL dalteparin sodium 25000 UNT/mL Prefilled Syringe [Fragmin] 	18000 [IU]
+00169-4525-14:	q493yxn -> 6bn759d	0.5 mL semaglutide 0.5 mg/mL Auto-Injector [Wegovy] 	0.25 mg
+00169-4525-94:	q493yxn -> 6bn759d	0.5 mL semaglutide 0.5 mg/mL Auto-Injector [Wegovy] 	0.25 mg
+50090-5824-00:	q493yxn -> 6bn759d	0.5 mL semaglutide 0.5 mg/mL Auto-Injector [Wegovy] 	0.25 mg
+49502-0500-92:	q94gwep -> 7v1pmyh	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+51662-1224-01:	q94gwep -> 7v1pmyh	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+70518-1224-00:	q94gwep -> 7v1pmyh	NDA019430 0.3 mL epinephrine 1 mg/mL Auto-Injector [Epipen] 	0.3 mg
+00002-1460-80:	q9vyrxn -> wrfmtma	0.5 mL tirzepatide 25 mg/mL Auto-Injector [Mounjaro] 	12.5 mg
+60842-0002-02:	qb7mv6z -> znv864g	0.4 mL naloxone HCl 25 mg/mL Auto-Injector 	10 mg
+49281-0405-65:	qdxyr7p -> 3s18yvz	Influenza a virus a/michigan/45/2015 x-275 (h1n1) antigen (formaldehyde inactivated), influenza a virus a/singapore/infimh-16-0019/2016 ivr-186 (h3n2) antigen (formaldehyde inactivated), and influenza b virus b/maryland/15/2016 bx-69a (a b/colorado/6/2017-like virus) antigen (formaldehyde inactivated) 0.06; 0.06; 0.06 mg; mg; mg Syringe [Fluzone High-Dose] 	0.06; 0.06; 0.06 mg; mg; mg
+00409-1316-32:	qkgmfzp -> vf9edgg	Heparin sodium 5000 [USP'U] Cartridge 	5000 [USP'U]
+00409-2721-01:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+00641-0410-12:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+25021-0403-01:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+63323-0542-01:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+63323-0542-13:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+63739-0964-25:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+67457-0602-99:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+71288-0404-02:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+71288-0424-96:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+81952-0113-06:	qkgmfzp -> p018anw	Heparin sodium 10000 [USP'U] Vial 	10000 [USP'U]
+00115-1695-30:	qrxdby6 -> h55h9gr	NDA020800 0.15 mL epinephrine 1 mg/mL Auto-Injector [Adrenaclick] 	0.15 mg
+00115-1695-49:	qrxdby6 -> h55h9gr	NDA020800 0.15 mL epinephrine 1 mg/mL Auto-Injector [Adrenaclick] 	0.15 mg
+51662-1222-01:	qrxdby6 -> h55h9gr	NDA020800 0.15 mL epinephrine 1 mg/mL Auto-Injector [Adrenaclick] 	0.15 mg
+50242-0080-01:	qt6ng71 -> m6cwt6j	0.05 mL ranibizumab 10 mg/mL Prefilled Syringe [Lucentis] 	0.5 mg
+50242-0080-02:	qt6ng71 -> m6cwt6j	0.05 mL ranibizumab 10 mg/mL Prefilled Syringe [Lucentis] 	0.5 mg
+55513-0223-01:	qyrqyyn -> 6exka2s	Romiplostim 0.125 mg Vial [Nplate] 	0.12 mg
+44087-3344-01:	rbac1vh -> b1f8gk2	0.5 mL interferon beta-1a 0.088 mg/mL Auto-Injector [Rebif] 	0.04 mg
+58406-0010-96:	rf7scnm -> w7nxnrz	0.5 mL etanercept 50 mg/mL Prefilled Syringe [Enbrel] 	25 mg
+15054-1060-04:	rm3vgga -> zpdh3vw	0.2 mL lanreotide 300 mg/mL Prefilled Syringe [Somatuline] 	60 mg
+15054-1090-04:	rm3vgga -> c3amb2x	0.3 mL lanreotide 300 mg/mL Prefilled Syringe [Somatuline] 	90 mg
+69097-0880-67:	rm3vgga -> zpdh3vw	0.2 mL lanreotide 300 mg/mL Prefilled Syringe [Somatuline] 	60 mg
+69097-0890-67:	rm3vgga -> c3amb2x	0.3 mL lanreotide 300 mg/mL Prefilled Syringe [Somatuline] 	90 mg
+76282-0709-67:	rm3vgga -> zpdh3vw	Lanreotide acetate 60 mg Syringe 	60 mg
+76282-0710-67:	rm3vgga -> c3amb2x	Lanreotide acetate 90 mg Syringe 	90 mg
+80064-0141-02:	rzcpgep -> 2pw7b7r	0.3 mL bremelanotide 5.83 mg/mL Auto-Injector [Vyleesi] 	1.75 mg
+80064-0141-04:	rzcpgep -> 2pw7b7r	0.3 mL bremelanotide 5.83 mg/mL Auto-Injector [Vyleesi] 	1.75 mg
+58160-0825-52:	s379xzt -> xwjywvj	0.5 mL hepatitis A vaccine (inactivated) strain HM175 1440 UNT/mL Prefilled Syringe [Havrix] 	720 [IU]
+00006-4109-02:	shxgvr1 -> yrmyb1e	Human papillomavirus quadrivalent (types 6, 11, 16, and 18) vaccine, recombinant 0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg Syringe [Gardasil] 	0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg
+00006-4109-09:	shxgvr1 -> yrmyb1e	Human papillomavirus quadrivalent (types 6, 11, 16, and 18) vaccine, recombinant 0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg Syringe [Gardasil] 	0.04; 0.04; 0.02; 0.02 mg; mg; mg; mg
+57894-0070-01:	sqqwmyp -> ytqrvsc	Golimumab 50 mg Syringe [Simponi] 	50 mg
+57894-0070-02:	sqqwmyp -> ytqrvsc	Golimumab 50 mg Syringe [Simponi] 	50 mg
+57894-0070-89:	sqqwmyp -> ytqrvsc	Golimumab 50 mg Syringe [Simponi] 	50 mg
+57894-0070-90:	sqqwmyp -> ytqrvsc	Golimumab 50 mg Syringe [Simponi] 	50 mg
+51662-1537-03:	sswyhpq -> 5v8srj2	0.5 mL vitamin K1 2 mg/mL Ampule 	1 mg
+49281-0722-10:	stttx7n -> befakkj	Influenza a virus a/wisconsin/588/2019 (h1n1) recombinant hemagglutinin antigen, influenza a virus a/darwin/6/2021 (h3n2) recombinant hemagglutinin antigen, influenza b virus b/austria/1359417/2021 recombinant hemagglutinin antigen, and influenza b virus b/phuket/3073/2013 recombinant hemagglutinin antigen 0.04; 0.04; 0.04; 0.04 mg; mg; mg; mg Syringe [Flublok Quadrivalent Northern Hemisphere] 	0.04; 0.04; 0.04; 0.04 mg; mg; mg; mg
+61314-0326-01:	t1pwjv2 -> 3zf2rvw	0.8 mL filgrastim-sndz 0.6 mg/mL Prefilled Syringe [Zarxio] 	0.48 mg
+61314-0326-10:	t1pwjv2 -> 3zf2rvw	0.8 mL filgrastim-sndz 0.6 mg/mL Prefilled Syringe [Zarxio] 	0.48 mg
+50632-0001-02:	t24wdy6 -> 7hwceaw	0.5 mL modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/mL Vial [Jynneos] 	50000000 nan
+50632-0001-03:	t24wdy6 -> 7hwceaw	0.5 mL modified Vaccinia Ankara-Bavarian Nordic 198000000 UNT/mL Vial [Jynneos] 	50000000 nan
+54436-0017-01:	t6qhh25 -> 32cvz1v	0.4 mL methotrexate 43.8 mg/mL Auto-Injector [Otrexup] 	17.5 mg
+54436-0017-03:	t6qhh25 -> 32cvz1v	0.4 mL methotrexate 43.8 mg/mL Auto-Injector [Otrexup] 	17.5 mg
+54436-0017-04:	t6qhh25 -> 32cvz1v	0.4 mL methotrexate 43.8 mg/mL Auto-Injector [Otrexup] 	17.5 mg
+00069-0196-02:	t9886ej -> b0nq245	0.2 mL dalteparin sodium 25000 UNT/mL Prefilled Syringe [Fragmin] 	5000 [IU]
+00069-0206-02:	t9886ej -> qhjpdhh	0.3 mL dalteparin sodium 25000 UNT/mL Prefilled Syringe [Fragmin] 	7500 [IU]
+47335-0276-40:	tknpa0r -> 3cm9zae	Sumatriptan succinate 6 mg Syringe 	6 mg
+11704-0104-01:	tq867wp -> w10hgz7	0.7 mL atropine sulfate 0.714 mg/mL Auto-Injector [Atropen] 	0.5 mg
+61314-0866-01:	v529ktq -> cd7fke2	0.6 mL pegfilgrastim-bmez 10 mg/mL Prefilled Syringe [Ziextenzo] 	6 mg
+49281-0590-05:	v7xqc1c -> e88k1z7	0.5 mL Neisseria meningitidis serogroup A capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup C capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup W-135 capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup Y capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL Vial [Menquadfi] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+50090-6180-00:	v7xqc1c -> e88k1z7	0.5 mL Neisseria meningitidis serogroup A capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup C capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup W-135 capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup Y capsular polysaccharide tetanus toxoid protein conjugate vaccine 0.02 mg/mL Vial [Menquadfi] 	0.01; 0.01; 0.01; 0.01 mg; mg; mg; mg
+50090-1831-00:	v9jrayh -> jnsyra1	Tetanus toxoid, reduced diphtheria toxoid and acellular pertussis vaccine, adsorbed 0.01; 0.0; 0.01; 5.0; 2.5 mg; mg; mg; [IU]; [IU] Vial [Boostrix] 	0.01; 0; 0.01; 5; 2.5 mg; mg; mg; [IU]; [IU]
+58160-0842-11:	v9jrayh -> jnsyra1	Tetanus toxoid, reduced diphtheria toxoid and acellular pertussis vaccine, adsorbed 0.01; 0.0; 0.01; 5.0; 2.5 mg; mg; mg; [IU]; [IU] Vial [Boostrix] 	0.01; 0; 0.01; 5; 2.5 mg; mg; mg; [IU]; [IU]
+72065-0140-11:	vajyysb -> cntf7tw	Glucagon (rDNA) 1 mg Carton [GlucaGen] 	1 mg
+72065-0141-11:	vajyysb -> cntf7tw	Glucagon (rDNA) 1 mg Vial [GlucaGen] 	1 mg
+11994-0017-01:	vgtxzre -> 1f8d6je	Perflutren 2.28 mg Vial [Definity Rt] 	2.28 mg
+11994-0017-20:	vgtxzre -> 1f8d6je	Perflutren 2.28 mg Vial [Definity Rt] 	2.28 mg
+49281-0400-05:	vhe3y04 -> s61ygk1	Clostridium tetani toxoid antigen (formaldehyde inactivated), corynebacterium diphtheriae toxoid antigen (formaldehyde inactivated), bordetella pertussis toxoid antigen (glutaraldehyde inactivated), bordetella pertussis filamentous hemagglutinin antigen (formaldehyde inactivated), bordetella pertussis pertactin antigen, and bordetella pertussis fimbriae 2/3 antigen 0.01; 0.01; 0.0; 0.0; 5.0; 2 mg; mg; mg; mg; [LF]; [LF] Vial [Adacel] 	0.01; 0.01; 0; 0; 5; 2 mg; mg; mg; mg; [LF]; [LF]
+49281-0400-10:	vhe3y04 -> s61ygk1	Clostridium tetani toxoid antigen (formaldehyde inactivated), corynebacterium diphtheriae toxoid antigen (formaldehyde inactivated), bordetella pertussis toxoid antigen (glutaraldehyde inactivated), bordetella pertussis filamentous hemagglutinin antigen (formaldehyde inactivated), bordetella pertussis pertactin antigen, and bordetella pertussis fimbriae 2/3 antigen 0.01; 0.01; 0.0; 0.0; 5.0; 2 mg; mg; mg; mg; [LF]; [LF] Vial [Adacel] 	0.01; 0.01; 0; 0; 5; 2 mg; mg; mg; mg; [LF]; [LF]
+78670-0130-02:	vj6pah1 -> 8xnmr65	0.3 mL epinephrine 1 mg/mL Prefilled Syringe [Symjepi] 	0.3 mg
+55513-0057-04:	vmy7yh1 -> 88w4gmf	0.42 mL darbepoetin alfa 0.06 mg/mL Prefilled Syringe [Aranesp] 	0.03 mg
+11704-0101-01:	vzg9chh -> b2w31x7	0.7 mL atropine sulfate 2.86 mg/mL Auto-Injector [Atropen] 	2 mg
+11704-0106-01:	vzg9chh -> b2w31x7	0.7 mL atropine sulfate 2.86 mg/mL Auto-Injector [Atropen] 	2 mg
+54436-0275-01:	w2db6pc -> 51qm544	0.5 mL testosterone enanthate 150 mg/mL Auto-Injector [Xyosted] 	75 mg
+54436-0275-04:	w2db6pc -> 51qm544	0.5 mL testosterone enanthate 150 mg/mL Auto-Injector [Xyosted] 	75 mg
+00781-3454-12:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+00781-3454-95:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+00781-3465-12:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+00781-3465-95:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+11797-0155-06:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+11797-0155-09:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+11797-0156-06:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+11797-0156-09:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+43598-0608-02:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+43598-0608-10:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+43598-0609-02:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+43598-0609-10:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+55111-0679-02:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+55111-0679-10:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+55111-0680-02:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+55111-0680-10:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+55150-0231-02:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+55150-0231-10:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+55150-0232-02:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+55150-0232-10:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+67457-0583-04:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+67457-0584-06:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+67457-0593-04:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+67457-0594-06:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+70710-1515-06:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+70710-1515-09:	w4mw9vg -> fb4ahzw	0.4 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	5 mg
+70710-1516-06:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+70710-1516-09:	w4mw9vg -> cjg0h56	0.6 mL fondaparinux sodium 12.5 mg/mL Prefilled Syringe [Arixtra] 	7.5 mg
+51662-1321-02:	w7pt5sd -> 9c0r9kp	NDA201739 0.15 mL epinephrine 1 mg/mL Auto-Injector [Auvi-Q] 	0.15 mg
+50242-0082-03:	wcats4p -> 2qr4cm5	Ranibizumab 0.3 mg Syringe [Lucentis] 	0.3 mg
+50242-0082-88:	wcats4p -> 2qr4cm5	Ranibizumab 0.3 mg Syringe [Lucentis] 	0.3 mg
+59137-0510-01:	wdcpbr6 -> j1pek1x	0.2 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	10 mg
+59137-0510-04:	wdcpbr6 -> j1pek1x	0.2 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	10 mg
+59137-0515-01:	wdcpbr6 -> 8xs1qqc	0.25 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	12.5 mg
+59137-0515-04:	wdcpbr6 -> 8xs1qqc	0.25 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	12.5 mg
+59137-0520-01:	wdcpbr6 -> 90kfqrk	0.3 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	15 mg
+59137-0520-04:	wdcpbr6 -> 90kfqrk	0.3 mL methotrexate 50 mg/mL Auto-Injector [Rasuvo] 	15 mg
+00069-0324-01:	we370p3 -> e9x4yf2	0.6 mL pegfilgrastim-apgf 10 mg/mL Prefilled Syringe [Nyvepria] 	6 mg
+78670-0131-02:	wqt11nm -> fnshded	Epinephrine 0.5 mg/mL Syringe 	0.15 mg
+00002-1434-61:	x5kma5c -> x4tbmkj	0.5 mL dulaglutide 3 mg/mL Auto-Injector [Trulicity] 	1.5 mg
+00002-1434-80:	x5kma5c -> x4tbmkj	0.5 mL dulaglutide 3 mg/mL Auto-Injector [Trulicity] 	1.5 mg
+50090-3483-00:	x5kma5c -> x4tbmkj	0.5 mL dulaglutide 3 mg/mL Auto-Injector [Trulicity] 	1.5 mg
+50090-6456-00:	x5kma5c -> x4tbmkj	0.5 mL dulaglutide 3 mg/mL Auto-Injector [Trulicity] 	1.5 mg
+00310-6540-04:	xc9ttb3 -> bmccf4v	0.85 mL exenatide 2.35 mg/mL Auto-Injector [Bydureon] 	2 mg
+59627-0002-06:	xfq2gsf -> cxydtvb	0.5 mL interferon beta-1a 0.06 mg/mL Prefilled Syringe [Avonex] 	0.03 mg
+51759-0520-10:	xk7tbq6 -> psv063q	0.28 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	100 mg
+51759-0520-11:	xk7tbq6 -> psv063q	0.28 mL risperidone 357 mg/mL Prefilled Syringe [Uzedy] 	100 mg
+55513-0190-01:	xm01h9c -> bhsqh7v	0.6 mL pegfilgrastim 10 mg/mL Prefilled Syringe [Neulasta] 	6 mg
+00006-4095-02:	xrw0by7 -> 66hnn49	Hepatitis a vaccine, inactivated 25 [IU] Syringe [Vaqta] 	25 [IU]
+00093-5985-27:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+49502-0101-02:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+49502-0501-02:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+51662-1225-01:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+63629-8801-01:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+70518-3173-00:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+71872-7134-01:	xx006p4 -> emqgcc9	NDA019430 0.3 mL epinephrine 0.5 mg/mL Auto-Injector [Epipen] 	0.15 mg
+66658-0234-07:	xy83y9y -> dhvxe21	0.67 mL anakinra 149 mg/mL Prefilled Syringe [Kineret] 	100 mg
+66658-0234-28:	xy83y9y -> dhvxe21	0.67 mL anakinra 149 mg/mL Prefilled Syringe [Kineret] 	100 mg
+64406-0015-01:	y09gm27 -> 13qvb36	0.5 mL peginterferon beta-1a 0.25 mg/mL Prefilled Syringe [Plegridy] 	0.12 mg
+64406-0017-01:	y09gm27 -> 13qvb36	0.5 mL peginterferon beta-1a 0.25 mg/mL Prefilled Syringe [Plegridy] 	0.12 mg
+00002-1495-80:	y0z7n56 -> 3xevce5	0.5 mL tirzepatide 10 mg/mL Auto-Injector [Mounjaro] 	5 mg
+00078-1056-97:	y34y9bq -> ex2gtsx	0.5 mL secukinumab 150 mg/mL Prefilled Syringe [Cosentyx] 	75 mg
+00078-1056-99:	y34y9bq -> ex2gtsx	0.5 mL secukinumab 150 mg/mL Prefilled Syringe [Cosentyx] 	75 mg
+82705-0010-01:	y4spz4j -> p8mp9ky	0.8 mL epcoritamab-bysp 60 mg/mL Vial [Epkinly] 	48 mg
+44087-0044-03:	y9x73z5 -> xddbs91	0.5 mL interferon beta-1a 0.088 mg/mL Prefilled Syringe [Rebif] 	0.04 mg
+25682-0013-12:	ycj12en -> py14dg6	0.7 mL asfotase alfa 40 mg/mL Vial [Strensiq] 	28 mg
+70121-1570-01:	ydsfpxn -> zev3w12	0.8 mL filgrastim-ayow 0.6 mg/mL Prefilled Syringe [Releuko] 	0.48 mg
+70121-1570-07:	ydsfpxn -> zev3w12	0.8 mL filgrastim-ayow 0.6 mg/mL Prefilled Syringe [Releuko] 	0.48 mg
+00169-4505-14:	yfy7fyk -> 2jcxzvw	0.5 mL semaglutide 1 mg/mL Auto-Injector [Wegovy] 	0.5 mg
+62935-0153-50:	yhq84ed -> 7s8tdpj	0.375 mL leuprolide acetate 120 mg/mL Prefilled Syringe [Fensolvi] 	0.38 mL
+80425-0245-01:	yv0papk -> zzh6ahb	Ketorolac tromethamine, lidocaine HCl, bupivacaine HCl, povidine iodine 1 mL Packet [Ketorocaine Lm Kit] 	1 mL
+54436-0010-01:	yvv8n60 -> zs2m64y	0.4 mL methotrexate 25 mg/mL Auto-Injector [Otrexup] 	10 mg
+54436-0010-03:	yvv8n60 -> zs2m64y	0.4 mL methotrexate 25 mg/mL Auto-Injector [Otrexup] 	10 mg
+54436-0010-04:	yvv8n60 -> zs2m64y	0.4 mL methotrexate 25 mg/mL Auto-Injector [Otrexup] 	10 mg
+63459-0912-11:	yw2h0dq -> z7qvbc9	0.8 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.48 mg
+63459-0912-15:	yw2h0dq -> z7qvbc9	0.8 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.48 mg
+63459-0912-17:	yw2h0dq -> z7qvbc9	0.8 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.48 mg
+63459-0912-36:	yw2h0dq -> z7qvbc9	0.8 mL tbo-filgrastim 0.6 mg/mL Prefilled Syringe [Granix] 	0.48 mg
+58160-0955-09:	ywhvcr6 -> hw4wmhd	0.5 mL Neisseria meningitidis serogroup A oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.02 mg/mL / Neisseria meningitidis serogroup C oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.01 mg/mL / Neisseria meningitidis serogroup W-135 oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.01 mg/mL / Neisseria meningitidis serogroup Y oligosaccharide diphtheria CRM197 protein conjugate vaccine 0.01 mg/mL Vial [Menveo] 	0.5 mL
+65649-0551-02:	yxdx1mr -> 7avdzav	Methylnaltrexone bromide 12 mg Vial [Relistor] 	12 mg
+68875-0101-02:	yzs35nf -> 20tgg0y	Teduglutide 5 mg Vial [Gattex] 	5 mg
+68803-0612-10:	yzs6pps -> 9drjbmk	Trypan blue 0.3 mg Syringe [Visionblue] 	0.3 mg
+49281-0225-10:	z272vga -> cac67rq	Diphtheria toxoid vaccine, inactivated 13.4 UNT/mL / tetanus toxoid vaccine, inactivated 10 UNT/mL Vial 	5; 25 [LF]; [LF]
+68727-0900-03:	z4d573q -> 7b6dysh	0.5 mL asparaginase Erwinia chrysanthemi (recombinant)-rywn 20 mg/mL Vial [Rylaze] 	10 mg
+50458-0560-01:	za9ae73 -> byx5zq4	0.25 mL paliperidone palmitate 156 mg/mL Prefilled Syringe [Invega] 	40 mg
+00173-0739-00:	zj5aevb -> ecsy1a3	0.5 mL sumatriptan 8 mg/mL Cartridge [Imitrex] 	4 mg
+00173-0739-02:	zj5aevb -> ecsy1a3	0.5 mL sumatriptan 8 mg/mL Cartridge [Imitrex] 	4 mg
+66993-0083-79:	zj5aevb -> ecsy1a3	0.5 mL sumatriptan 8 mg/mL Cartridge [Imitrex] 	4 mg
+66993-0083-98:	zj5aevb -> ecsy1a3	0.5 mL sumatriptan 8 mg/mL Cartridge [Imitrex] 	4 mg
+49281-0511-05:	zmt1t47 -> jqh68q8	0.5 mL acellular pertussis vaccine, inactivated 96 UNT/mL / diphtheria toxoid vaccine, inactivated 30 UNT/mL / Haemophilus influenzae type b, capsular polysaccharide inactivated tetanus toxoid conjugate vaccine 68 UNT/mL / poliovirus vaccine inactivated, type 1 (Mahoney) 58 UNT/mL / poliovirus vaccine inactivated, type 2 (MEF-1) 14 UNT/mL / poliovirus vaccine inactivated, type 3 (Saukett) 52 UNT/mL / tetanus toxoid vaccine, inactivated 20 UNT/mL Vial [Pentacel] 	0.5 mL
+65649-0551-03:	zpphkbf -> ek1va6d	Methylnaltrexone bromide 12 mg Syringe [Relistor] 	12 mg
+65649-0551-07:	zpphkbf -> ek1va6d	Methylnaltrexone bromide 12 mg Syringe [Relistor] 	12 mg
+65649-0552-04:	zpphkbf -> pc9d4x9	0.4 mL methylnaltrexone bromide 20 mg/mL Prefilled Syringe [Relistor] 	8 mg
+00069-0291-01:	zwj763k -> nt1gmfs	0.5 mL filgrastim-aafi 0.6 mg/mL Prefilled Syringe [Nivestym] 	0.3 mg
+00069-0291-10:	zwj763k -> nt1gmfs	0.5 mL filgrastim-aafi 0.6 mg/mL Prefilled Syringe [Nivestym] 	0.3 mg
+00093-2013-12:	zysmk5h -> h5k8a99	Sumatriptan succinate 4 mg Syringe [Sumatriptan] 	4 mg
+00498-4141-01:	1rx417z -> nsfp3kz	4141 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4399-01:	1rx417z -> dx0mbcj	4399 first aid 0.3 mL Pouch [4399 First Aid Kit] 	0.3 mL
+00498-4131-01:	24f0ta0 -> 7kymb47	4131 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4379-01:	2q4nh7x -> 3tmh7z	4379 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4370-01:	2w2rqcs -> dac389w	4370 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4292-01:	33t2wmm -> ftvqqyf	4292 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4150-01:	3gwjtgq -> vga0nzs	4150 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4152-01:	3gwjtgq -> 9gwe5wd	4152 first aid 0.4 mL Pouch [4152 First Aid Kit] 	0.4 mL
+00498-4156-01:	3gwjtgq -> vga0nzs	4156 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4253-01:	3wwy7pr -> qmwrty9	4253 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4254-01:	3wwy7pr -> qmwrty9	4254 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4255-01:	3wwy7pr -> qmwrty9	4255 first aid kit 1 mL/mL Packet 	1 mL/mL
+58160-0824-15:	4j2v430 -> 18fbk70	Measels, mumps, and rubella vaccine, live 0.5 mL Syringe [Priorix] 	0.5 mL
+00498-4373-01:	5p14yr7 -> s34y24t	4373 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4386-01:	62d34rs -> r988dp6	4386 first aid 1 mL/mL Packet [4386 First Aid Kit] 	1 mL/mL
+00498-4235-01:	6d70mhy -> 72fz2qk	4235 first aid 0.4 mL Pouch [4235 First Aid Kit] 	0.4 mL
+00498-4280-01:	6r59fax -> 8drj8ex	4280 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4218-01:	70atbp4 -> h72kbg6	4218 first aid 0.3 mL Ampule [4218 First Aid Kit] 	0.3 mL
+00498-4197-01:	7qbf6p6 -> tdcn4qa	4197 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4198-01:	7qbf6p6 -> tdcn4qa	4198 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4199-01:	7qbf6p6 -> tdcn4qa	4199 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4065-01:	8y7trmw -> x5wwhs1	4065 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4067-01:	8y7trmw -> x5wwhs1	4067 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4167-01:	93rdad6 -> tgfw33b	4167 first aid 0.4 mL Pouch [4167 First Aid Kit] 	0.4 mL
+00498-4334-01:	9e2dd5y -> pgb4qfk	4334 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4361-01:	9tgyytb -> ejp6mxq	4361 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4163-01:	a6rbebz -> hbngwjp	4163 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4165-01:	a7wbbcj -> kcw2abb	4165 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4269-01:	aawxgqf -> nes1kp7	4269 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4169-01:	an0zfbb -> p5we4kq	4169 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4195-01:	atn7pph -> q57psah	4195 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4384-01:	b5yhhgy -> 1c37f9r	4384 first aid 1 mL/mL Packet [4384 First Aid Kit] 	1 mL/mL
+00498-4300-01:	bg4b9cb -> ftvqqyf	4300 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4312-01:	c2a3syp -> tygeh9x	4312 first aid kit 0.4 mL Pouch 	0.4 mL
+64406-0012-01:	crhpc8q -> j69x8pb	Peginterferon beta-1a 0.5 mL Pack [Plegridy] 	0.5 mL
+00498-4223-01:	crsmtwv -> 70atbp4	4223 first aid kit 1 mL/mL Packet 	1 mL/mL
+70529-0941-01:	ct2scz0 -> eeb6b4f	Lidocaine HCl 1 mL/mL Packet [Sx1 Medicated Post-Operative System] 	1 mL/mL
+00498-4247-01:	d0jhe67 -> q1khkcx	4247 first aid kit 0.3 mL Ampule 	0.3 mL
+00498-4155-01:	dac389w -> ncfdev5	4155 first aid 0.3 mL Ampule [4155 First Aid Kit] 	0.3 mL
+00498-4320-01:	dpwvkdg -> m1t2qdr	4320 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4401-01:	eej83ma -> x4w5aag	4401 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4074-01:	eey9r7v -> 98j0sfd	4074 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4261-01:	eey9r7v -> gc1fpp1	4261 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4350-01:	ejp6mxq -> svnsqqk	4350 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4185-01:	emv7hzx -> tz52khd	4185 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4186-01:	emv7hzx -> tz52khd	4186 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4330-01:	eqnqkzy -> 4w9cxfy	4330 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4336-01:	esav8fc -> 4w9cxfy	4336 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4337-01:	esav8fc -> 4w9cxfy	4337 first aid kit 1 mL/mL Packet 	1 mL/mL
+70529-0254-01:	etc5pbc -> 1z8kyff	Lidocaine HCl 0.55 mL Pouch [Venipuncture Px1] 	0.55 mL
+00498-4378-01:	fc9za3q -> srjm113	4378 first aid kit 0.4 mL Pouch 	0.4 mL
+64406-0016-01:	g91bd8s -> emfwe6s	Peginterferon beta-1a 0.5 mL Pack [Plegridy] 	0.5 mL
+00498-4366-01:	j60nw2w -> c0kan86	4366 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4368-01:	j60nw2w -> c0kan86	4368 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4147-01:	j79wsxd -> 4nwzmyy	4147 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4140-01:	j808tzf -> 22e0d4v	4140 first aid 0.3 mL Pouch [4140 First Aid Kit] 	0.3 mL
+00498-4275-01:	jh4brpv -> xyresba	4275 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4145-01:	jvst02a -> ba0gzq7	4145 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4250-01:	kf4mf4y -> qmwrty9	4250 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4264-01:	m3bs2kf -> gc1fpp1	4264 first aid kit 1 mL Package 	1 mL
+00498-4007-01:	ma5admf -> gc1fpp1	4007 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4013-01:	ma5admf -> gc1fpp1	4013 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4072-01:	mqjk721 -> c34mh6t	4072 first aid kit 0.4 mL Pouch [4072First Aid Kit] 	0.4 mL
+00498-4385-01:	mxast4c -> pbckbqq	4385 first aid 1 mL/mL Packet [4385 First Aid Kit] 	1 mL/mL
+00498-4352-01:	n1bfzvc -> ejp6mxq	4352 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4397-01:	n24tzc3 -> 2q4nh7x	4397 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4233-01:	n2q74ev -> ce0eggg	4233 first aid 0.3 mL Pouch [4233 First Aid Kit] 	0.3 mL
+00498-4281-01:	nhr7qpv -> 8drj8ex	4281 first aid 1 mL/mL Packet [4281 First Aid Kit] 	1 mL/mL
+00498-4283-01:	nhr7qpv -> 8drj8ex	4283 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4284-01:	nhr7qpv -> 8drj8ex	4284 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4285-01:	nhr7qpv -> 8drj8ex	4285 first aid kit 1 mL/mL Packet 	1 mL/mL
+83220-0001-11:	p1vfq0p -> xv07gz	Epinephrine, albuterol sulfate, nitroglycerin, diphenhydramine HCl, aspirin 0.3 mL Syringe [Deluxe Dental Emergency Kit] 	0.3 mL
+00498-4171-01:	pfpda77 -> n2q74ev	4171 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4236-01:	qeg1jf5 -> ce0eggg	4236 first aid kit 0.3 mL Pouch 	0.3 mL
+27860-0014-01:	rajcggs -> sp8v7c6	Model aa-2012 0.55 mL Packet 	0.55 mL
+00498-4298-01:	rtatr5y -> c6sfa87	4298 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4333-01:	t082nkd -> nxtm9hg	4333 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4238-01:	vb0dh7y -> 7mpbhkw	4238 first aid kit 1 mL/mL Packet 	1 mL/mL
+83220-0002-08:	ve20p7z -> 34s109v	Epinephrine, albuterol sulfate, nitroglycerin, diphenhydramine HCl, aspirin 0.3 mL Syringe [Basic Dental Emergency Kit] 	0.3 mL
+00498-4183-01:	vga0nzs -> 9gwe5wd	4183 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-9000-01:	vk21t72 -> ve81c4a	Isopropyl alcohol 0.4 mL Pouch [Rescue Breather Kit] 	0.4 mL
+00498-4201-01:	wpvkw37 -> bfnjx51	4201 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4202-01:	wpvkw37 -> bfnjx51	4202 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4249-01:	x82h0yg -> e5gf0a2	4249 first aid kit 1 mL/mL Packet 	1 mL/mL
+00498-4375-01:	xac8arq -> ms51vxg	4375 first aid kit 0.3 mL Pouch 	0.3 mL
+00074-0067-02:	xr49mmf -> yacndna	Adalimumab 0.8 mL Pack [Humira] 	0.8 mL
+00498-4130-01:	ymapyrd -> fzfk3mk	4130 first aid kit 0.3 mL Pouch 	0.3 mL
+00498-4348-01:	zdf8y52 -> xw53xrk	4348 first aid 0.4 mL Pouch [4348 First Aid Kit] 	0.4 mL
+00498-4294-01:	zeyf236 -> 3v8p7jm	4294 first aid kit 0.3 mL Pouch 	0.3 mL
+00074-1539-03:	zgfejtm -> nj7j806	Adalimumab 0.8 mL Pack [Humira] 	0.8 mL
+00498-4391-01:	zs5r5vv -> dfv8m0q	4391 first aid 0.4 mL Pouch [4391 First Aid Kit] 	0.4 mL
+00498-4395-01:	zs5r5vv -> dfv8m0q	4395 first aid kit 0.4 mL Pouch 	0.4 mL
+00498-4302-01:	zzfchqh -> 7ns78vg	4302 first aid kit 0.4 mL Pouch 	0.4 mL
+49967-0303-04:	14g7fe7 -> 9aa21be	Octinoxate and titanium dioxide 26.8; 46 mg; mg Package [Lancome Paris Teint Idole Ultra Wear Breathable Coverage Foundation Reno Broad Spectrum Spf 25 Sunscreen] 	26.8; 46 mg; mg
+00363-9999-01:	1k862k7 -> 8hrb0za	Onion, calcium sulfide, goldenseal, sodium chloride, phosphorus, anemone pulsatilla, and sulfur 708.0; 1416.0; 708.0; 708.0; 1416.0; 708.0; 1416 [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X] Bottle [Childrens Cold And Cough Grape Flavor] 	708; 1416; 708; 708; 1416; 708; 1416 [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]
+64942-1633-01:	1w0vmme -> 4n1ya7n	Aluminum chloride 4.26 mg Packet [Dr Sweat] 	4.26 mg
+49967-0956-07:	1xaskda -> apx0wdr	Octinoxate 9 mg Container [Lancome Paris Teint Idole Ultra 24H Makeup Broad Spectrum Spf 15 Sunscreen] 	9 mg
+30142-0845-43:	4axw6tn -> 5x58sq0	Isopropyl alcohol 0.7 mL/mL Topical Solution 	289.95 mg
+77006-0001-04:	4kqbakw -> y80k9y3	Alcohol 589436 mg Bottle [Weclean Hand Sanitizer Gel - Eucalyptus] 	589436 mg
+66096-0751-08:	58qzekm -> 8y5h2yp	Aralia racemosa 0.25  Bottle [Aralia Racemosa Mt] 	0.25 nan
+79832-0301-80:	amgdfg7 -> hjf8y3f	Benzalkonium chloride 4.91 mg Jug [Hand Sanitizer] 	4.91 mg
+71734-0342-01:	bw9kbz6 -> xt0b3z3	Alcohol 558 mg Dose Pack [Keep Going Hand Sanitizer] 	558 mg
+59051-7100-02:	c4x1rep -> dw9mrvv	Hand sanitizer 67764 mg Bottle [Companion Hand Sanitizer] 	67764 mg
+77006-0030-01:	cksgnbn -> mddt442	Alcohol 146000 mg Bottle [Weclean Hand Sanitizer Pumpkin Swirl] 	146000 mg
+63388-0915-15:	cqnngdp -> wa6rstv	Drosera, arnica montana, bryonia, cetraria islandica, coccus cacti, corallium rubrum, stannum metallicum, chamomilla, coffee crudea 4.0; 3.0; 3.0; 1.0; 4.0; 3.0; 1.0; 3.0; 3 [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C] Bottle [Kids Relief] 	4; 3; 3; 1; 4; 3; 1; 3; 3 [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]
+63388-0920-45:	cqnngdp -> wa6rstv	Drosera, arnica montana, bryonia, cetraria islandica, coccus cacti, corallium rubrum, stannum metallicum, camomilla, coffea crudea 4.0; 3.0; 3.0; 1.0; 4.0; 3.0; 1.0; 3.0; 3 [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C] Bottle [Real Relief] 	4; 3; 3; 1; 4; 3; 1; 3; 3 [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]; [HP_C]
+69842-0718-21:	csbqjya -> nngm31f	Undecylenic acid 10 mg Bottle [Cvs Pharmacy] 	10 mg
+00924-0017-01:	djy4nry -> 67h1cc9	Isopropyl alcohol 0.28 mL Pouch [First Aid Only Alcohol Antiseptic] 	0.28 mL
+83243-0001-01:	ekknj6n -> qv7wmh0	Melissa officinalis leaf,thuja occidentalis leaf,geranium maculatum,calendula officinalls 3.0; 3.0; 3.0; 3 [HP_X]; [HP_X]; [HP_X]; [HP_X] Applicator [Azzurx] 	3; 3; 3; 3 [HP_X]; [HP_X]; [HP_X]; [HP_X]
+77615-0100-16:	ep362zz -> g0jxj7f	Ethyl alcohol 0.3 L Bottle [Zatural Hand Sanitizer] 	0.3 L
+79832-0301-08:	f9waqar -> spaz15f	Benzalkonium chloride 0.31 mg Bottle [Hand Sanitizer] 	0.31 mg
+70631-0577-03:	fv6y1y9 -> 6rvh8j7	Hand sanitizer 1.95 mL Pouch [Thieves Waterless Hand Sanitizer] 	1.95 mL
+80851-0302-01:	gvzah77 -> p3psjah	Chitosan 0.02 mg Bottle [Vial Kit3.98] 	0.02 mg
+66096-0762-08:	hwfyebg -> k8pft7z	Convallaria majalis 1 [HP_X] Bottle [Convallaria Majalis Mt] 	1 [HP_X]
+77615-0100-08:	j0ymxpc -> 1t9wsqt	Ethyl alcohol 0.15 L Bottle [Zatural Hand Sanitizer] 	0.15 L
+77615-0100-02:	j88ksmh -> zgppmfd	Ethyl alcohol 0.04 L Bottle [Zatural Hand Sanitizer] 	0.04 L
+79832-0301-16:	j8w562a -> 2ce8wqr	Benzalkonium chloride 0.62 mg Bottle [Hand Sanitizer] 	0.62 mg
+49527-0080-03:	k153ms8 -> ft5n6zn	Titanium dioxide, zinc oxide 4.8; 11.8 mg; mg Packet [Clinique Even Better Clinical Serum Foundation Broad Spectrum Spf 25] 	4.8; 11.8 mg; mg
+79832-0401-14:	k3r1sks -> pndf51c	Benzalkonium chloride 0.53 mg Bottle [Kleen Start Hand Sanitizer] 	0.53 mg
+68078-0024-02:	kcrtq79 -> 1vggkp7	Titanium dioxide and zinc oxide 39.5; 33.5 mg; mg Packet [Total Eye 3-In-1 Renewal Therapy Spf 35] 	39.5; 33.5 mg; mg
+69103-5100-00:	kx1q9k6 -> 349j5ht	Lidocaine HCl 2124 mg Bottle 	2124 mg
+00498-3111-34:	mspejdy -> gj7nz75	Ethyl alcohol 1.26 mL Packet [Paws] 	1.26 mL
+77396-0001-03:	pfef7sr -> n26che1	Didecyldimonium chloride and benzalkonium chloride liquid 75.0; 187.5 mg; mg Bottle [Sanivir Hands, Body, And Surfaces Sanitizer] 	75; 187.5 mg; mg
+81351-0001-01:	tzkcvb9 -> tm6w2t6	Alcohol 0 L Packet [Saninta Antiseptic Wipe] 	0 L
+49967-0302-04:	v973agy -> ya6xbk4	Octinoxate and titanium dioxide 26.8; 20.4 mg; mg Package [Lancome Paris Teint Idole Ultra Wear Breathable Coverage Foundation Broad Spectrum Spf 25 Sunscreen] 	26.8; 20.4 mg; mg
+72393-0306-02:	4knk3aa -> 26n9pft	Menthol 0.7 mg Tube [Aromalief Soothing Pain Relief Cream Spearmint] 	0.7 mg
+10356-0111-30:	5ghh01m -> jqrzg3e	Petrolatum, avobenzone, octinoxate, octisalate, octocrylene, oxybenzone 27.0; 60.75; 40.5; 18.0; 48.6; 280 mg; mg; mg; mg; mg; mg Packet [Aquaphor Lip Protectant And Sunscreen] 	27; 60.75; 40.5; 18; 48.6; 280 mg; mg; mg; mg; mg; mg
+69423-0194-01:	8ed50c7 -> athykxr	Octinoxate and zinc oxide 30.0; 15 mg; mg Pouch [Olay Complete Uv365 Daily Moisturizer Sensitive] 	30; 15 mg; mg
+62217-0245-49:	a8y81ha -> zndpss5	Avobenzone, homosalate, octisalate, octocrylene 1260.0; 4200.0; 1900.0; 3360 mg; mg; mg; mg Bottle [Cabana Beach Club With Manuka Honey And Essential Oils Spf 50 Sunscreen] 	1260; 4200; 1900; 3360 mg; mg; mg; mg
+72393-0301-02:	aj20ngj -> qrr0dem	Menthol 0.7 mg Tube [Aromalief Pain Relief Cream Orange Ginger] 	0.7 mg
+72393-0302-02:	cd48z9g -> fd43k9w	Menthol 0.7 mg Tube [Aromalief Calming Pain Relief Cream Lavender] 	0.7 mg
+72393-0306-04:	gytdh86 -> ceay6c6	Menthol 1.4 mg Tube [Aromalief Soothing Pain Relief Cream Spearmint] 	1.4 mg
+49967-0050-02:	kxh04vr -> sjds3xf	Titanium dioxide and zinc oxide 13.5; 6 mg; mg Packet [Skinceuticals Physical Eye Uv Defense Sunscreen] 	13.5; 6 mg; mg
+61995-2029-02:	ma4a52r -> k3r6s4n	Avobenzone, homosalate, octocrylene, octisalate 2670.0; 9000.0; 4450.0; 9000 mg; mg; mg; mg Tube [Alba Botanica Spf 50 Sunscreen] 	2670; 9000; 4450; 9000 mg; mg; mg; mg
+83005-0001-01:	mggg4z9 -> v5ybfcy	Zinc oxide 9000 mg Tube [Sqween 100% Mineral Sunscreen Broad Spectrum Spf 30 Water Resistant] 	9000 mg
+14141-0990-08:	mk14tm5 -> wfmh4qn	Avobenzone, homosalate, and octocrylene 2.1; 7.0; 5.6 mg; mg; mg Packet [Lbel Defense Total Broad Spectrum Spf 50Plus Sunscreen For Face And Body] 	2.1; 7; 5.6 mg; mg; mg
+72393-0302-04:	q6t8z9p -> my69hx0	Menthol 1.4 mg Tube [Aromalief Calming Pain Relief Cream Lavender] 	1.4 mg
+61995-2029-03:	shqzsb0 -> j0rbwt8	Avobenzone, homosalate, octocrylene, octisalate 3400.0; 11300.0; 5650.0; 11300 mg; mg; mg; mg Tube [Alba Botanica Spf 50 Sunscreen] 	3400; 11300; 5650; 11300 mg; mg; mg; mg
+61995-2029-01:	we9dfvp -> p1z8ze4	Avobenzone, homosalate, octocrylene, octisalate 1770.0; 6000.0; 2950.0; 6000 mg; mg; mg; mg Tube [Alba Botanica Spf 50 Sunscreen] 	1770; 6000; 2950; 6000 mg; mg; mg; mg
+72393-0301-04:	wxda29d -> dh09vj6	Menthol 1.4 mg Tube [Aromalief Pain Relief Cream Orange Ginger] 	1.4 mg
+49967-0180-04:	zjd8xyf -> 71w6g5x	Octinoxate and titanium dioxide 20.1; 5.4 mg; mg Packet [Valentino Very Valentino Light Lasting Perfecting Foundation Broad Spectrum Spf 26 Sunscreen] 	20.1; 5.4 mg; mg
+68599-0465-09:	5cck8qg -> brxms8x	Cough suppressant 739.6 mg Jar [Menthol] 	739.6 mg
+68599-0464-09:	7nv52p0 -> 3z8seff	Cough suppressant 500 mg Jar [Menthol] 	500 mg
+37000-0894-18:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+37000-0894-20:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+37000-0894-45:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+69423-0900-05:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+69423-0900-18:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+69423-0900-45:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+69423-0957-18:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+69423-0957-45:	sm1rwsz -> jet96q6	Menthol 20 mg Lozenge [Vicks Vapocool] 	20 mg
+55910-0171-34:	ctnnpm4 -> 69vsgxz	Hydrogen peroxide 15 mg/mL Mouthwash [Peroxi-Fresh] 	0.35 mg
+42961-0810-03:	71pp5ks -> j1nkq8y	Benzocaine 200 mg/mL Mucous Membrane Topical Solution [Anbesol] 	100 mg
+42961-0810-04:	71pp5ks -> j1nkq8y	Benzocaine 200 mg/mL Mucous Membrane Topical Solution [Anbesol] 	100 mg
+68421-8100-03:	71pp5ks -> j1nkq8y	Benzocaine 200 mg/mL Mucous Membrane Topical Solution [Anbesol] 	100 mg
+68421-8100-04:	71pp5ks -> j1nkq8y	Benzocaine 200 mg/mL Mucous Membrane Topical Solution [Anbesol] 	100 mg
+00283-0610-11:	b7v6twj -> b50fp9m	Benzocaine 200 mg/mL Mucosal Spray [Hurricaine] 	98.4 mg
+00283-0610-26:	b7v6twj -> b50fp9m	Benzocaine 200 mg/mL Mucosal Spray [Hurricaine] 	98.4 mg
+47682-0224-12:	4g5pkz0 -> 1d7s9vw	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate 200.0; 1.75; 2500 [USP'U]; mg; [USP'U] Packet [Medi-First Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0224-35:	4g5pkz0 -> 1d7s9vw	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate 200.0; 1.75; 2500 [USP'U]; mg; [USP'U] Packet [Medi-First Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0224-73:	4g5pkz0 -> 1d7s9vw	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate 200.0; 1.75; 2500 [USP'U]; mg; [USP'U] Packet [Medi-First Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0932-73:	4g5pkz0 -> 1d7s9vw	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate 200.0; 1.75; 2500 [USP'U]; mg; [USP'U] Packet [Medi-First Plus Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+59961-0153-45:	4g5pkz0 -> 1d7s9vw	Bacitracin zinc, neomycin sulfate, polymyxin b sulfate 200.0; 1.75; 2500 [USP'U]; mg; [USP'U] Packet [Travel Savvy Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+59898-0740-01:	chjdyf1 -> f0m7wqg	Bacitracin zinc, polymyxin b sulfate, neomycin sulfate 376.02; 3.15; 4790.52 [IU]; mg; [IU] Packet [Water-Jel 3-In-1 Antibiotic] 	376.02; 3.15; 4790.52 [IU]; mg; [IU]
+59898-0740-02:	chjdyf1 -> f0m7wqg	Bacitracin zinc, polymyxin b sulfate, neomycin sulfate 376.02; 3.15; 4790.52 [IU]; mg; [IU] Packet [Water-Jel 3-In-1 Antibiotic] 	376.02; 3.15; 4790.52 [IU]; mg; [IU]
+59898-0740-03:	chjdyf1 -> f0m7wqg	Bacitracin zinc, polymyxin b sulfate, neomycin sulfate 376.02; 3.15; 4790.52 [IU]; mg; [IU] Packet [Water-Jel 3-In-1 Antibiotic] 	376.02; 3.15; 4790.52 [IU]; mg; [IU]
+59898-0740-38:	chjdyf1 -> d462q1z	Bacitracin zinc, polymyxin b sulfate, neomycin sulfate 209.0; 1.75; 2661.4 [IU]; mg; [IU] Packet [Water-Jel 3-In-1 Antibiotic] 	209; 1.75; 2661.4 [IU]; mg; [IU]
+45802-0060-70:	e50w6yt -> sfjs5df	Bacitracin 450 [USP'U] Packet 	450 [USP'U]
+50090-0845-00:	e50w6yt -> sfjs5df	Bacitracin 450 [USP'U] Packet 	450 [USP'U]
+68001-0477-48:	e50w6yt -> sfjs5df	Bacitracin 450 [IU] Packet 	450 [IU]
+59898-0740-34:	e8b6kww -> f0m7wqg	Bacitracin zinc, polymyxin b sulfate, neomycin sulfate 376.02; 3.15; 4790.52 [IU]; mg; [IU] Packet [Water-Jel 3-In-1 Antibiotic] 	376.02; 3.15; 4790.52 [IU]; mg; [IU]
+00924-5632-01:	fqdb1af -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+00924-5632-02:	fqdb1af -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+00924-5632-03:	fqdb1af -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+00924-5632-04:	fqdb1af -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+00924-5632-05:	fqdb1af -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+00924-5632-06:	fqdb1af -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+63736-0041-24:	gqq4056 -> 95dqk23	Benzocaine 5600 mg Tube [Boil Ease] 	5600 mg
+51885-9482-08:	j3njh6e -> ex523x6	Aconitum napellus, arnica montana root, atropa belladonna, bellis perennis, calendula officinalis flowering top, matricaria recutita, echinacea, unspecified, echinacea purpurea, hamamelis virginiana root bark/stem bark, calcium sulfide, hypericum perforatum, mercurius solubilis, achillea millefolium and comfrey root 100.0; 100.0; 300.0; 100.0; 100.0; 600.0; 100.0; 400.0; 100.0; 100.0; 100.0; 600.0; 100.0; 600 [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X] Tube [Traumeel Rx] 	100; 100; 300; 100; 100; 600; 100; 400; 100; 100; 100; 600; 100; 600 [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]
+51885-9487-08:	j3njh6e -> ex523x6	Aconitum napellus, arnica montana root, atropa belladonna, bellis perennis, calendula officinalis flowering top, matricaria recutita, echinacea, unspecified, echinacea purpurea, hamamelis virginiana root bark/stem bark, calcium sulfide, hypericum perforatum, mercurius solubilis, achillea millefolium and comfrey root 100.0; 100.0; 300.0; 100.0; 100.0; 600.0; 100.0; 400.0; 100.0; 100.0; 100.0; 600.0; 100.0; 600 [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X] Tube [Traumeel] 	100; 100; 300; 100; 100; 600; 100; 400; 100; 100; 100; 600; 100; 600 [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]; [HP_X]
+00924-5632-00:	rhndts4 -> 735ffmw	Anti-itch cream 9 mg Packet [Hydrocortisone] 	9 mg
+59898-0740-36:	rkqt0ef -> d462q1z	Bacitracin zinc, polymyxin b sulfate, neomycin sulfate 209.0; 1.75; 2661.4 [IU]; mg; [IU] Packet [Water-Jel 3-In-1 Antibiotic] 	209; 1.75; 2661.4 [IU]; mg; [IU]
+61010-5601-02:	ztq2fre -> nsj3szb	Bacitracin zinc 360 [USP'U] Pouch [Single Antibiotic With Bacitracin] 	360 [USP'U]
+61010-5601-03:	ztq2fre -> nsj3szb	Bacitracin zinc 360 [USP'U] Pouch [Single Antibiotic With Bacitracin] 	360 [USP'U]
+70082-0601-02:	ztq2fre -> nsj3szb	Bacitracin zinc 360 [USP'U] Pouch [Single Antibiotic With Bacitracin] 	360 [USP'U]
+00065-0543-01:	14e8jbg -> sd5v8z7	1 mL triamcinolone acetonide 40 mg/mL Vial [Triesence] 	40 mg
+24208-0602-06:	1tkm0c1 -> 97vke6w	Bromfenac 0.7 mg/mL Ophthalmic Solution [Prolensa] 	0.42 mg
+53799-0302-12:	20nhcgc -> rxhevp3	Apis mellifera, euphrasia stricta and schoenocaulon officinale seed 5.33; 5.33; 5.33 [HP_X]; [HP_X]; [HP_X] Bottle [Allergy Eye Relief] 	5.33; 5.33; 5.33 [HP_X]; [HP_X]; [HP_X]
+00065-8150-04:	460tb4k -> g840cyc	Olopatadine 2 mg/mL Ophthalmic Solution [Pataday] 	1 mg
+64108-0212-65:	4nz2jyn -> 8hqjrse	Polyvinyl alcohol 0.014 mL/mL / povidone 6 mg/mL Ophthalmic Solution [MiniDrops] 	7; 3 mg; mg
+70290-0120-05:	5tkfja3 -> hmtb4q2	Chlorhexidine gluconate and propylene glycol 0.05; 0.1 KG; KG Bottle [Eyewash Station Additive Concentrate] 	0.05; 0.1 KG; KG
+00023-0403-05:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00023-0403-10:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00023-0403-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00023-0403-50:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00023-0403-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00113-0323-65:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00363-4809-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00363-4816-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00363-8800-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00363-8800-02:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00536-1387-92:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00536-1387-93:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00904-6329-46:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00904-6329-51:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00904-6848-46:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00904-6848-51:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+11673-0126-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+11673-0150-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+11673-0636-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+21130-0705-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+30142-0373-33:	65vh77s -> 9eewx8y	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2.5 mg
+36800-0641-65:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+37808-0100-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+46122-0195-65:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+49035-0245-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+49035-0389-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+49035-0657-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+49348-0329-44:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+50268-0067-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+50268-0067-50:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+50268-0067-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+56062-0789-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+59276-0403-05:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+59276-0403-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+59276-0905-05:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+62011-0203-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+63868-0618-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+65923-0555-02:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+69842-0804-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+69842-0993-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+70000-0012-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+70000-0012-02:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+70000-0352-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+70677-1190-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+76162-0089-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+79481-0066-01:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+79481-0066-02:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+79662-0001-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+79662-0002-30:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+79662-0002-70:	65vh77s -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+00065-0431-33:	771v5sd -> 7vxfdwt	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	2.8; 2.1 mg; mg
+00065-1432-04:	771v5sd -> 7vxfdwt	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	2.8; 2.1 mg; mg
+00065-1432-05:	771v5sd -> 7vxfdwt	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	2.8; 2.1 mg; mg
+00065-1432-06:	771v5sd -> 7vxfdwt	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	2.8; 2.1 mg; mg
+00065-1437-04:	771v5sd -> 7vxfdwt	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	2.8; 2.1 mg; mg
+00065-1437-05:	771v5sd -> 7vxfdwt	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	2.8; 2.1 mg; mg
+55651-0017-01:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+69842-0746-01:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+69842-0752-01:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+69842-0752-02:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+70000-0017-01:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+70000-0501-01:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+73669-0013-02:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+79903-0131-30:	771v5sd -> 6bjjj4j	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+24208-0006-05:	7xv7brm -> 15strf0	Glycerin 5 mg/mL Ophthalmic Solution [Regener-Eyes] 	1.5 mg
+47335-0506-96:	8c12etw -> qx93xxr	Cyclosporine 0.9 mg/mL Ophthalmic Solution [Cequa] 	0.23 mg
+00023-3416-05:	9mxgh04 -> 68c22w6	Carboxymethylcellulose sodium 5 mg/mL / glycerin 9 mg/mL Ophthalmic Solution 	2; 3.6 mg; mg
+00023-3416-30:	9mxgh04 -> 68c22w6	Carboxymethylcellulose sodium 5 mg/mL / glycerin 9 mg/mL Ophthalmic Solution 	2; 3.6 mg; mg
+00023-3416-60:	9mxgh04 -> 68c22w6	Carboxymethylcellulose sodium 5 mg/mL / glycerin 9 mg/mL Ophthalmic Solution 	2; 3.6 mg; mg
+24208-0742-01:	9ts4reh -> fbkqm76	Mineral oil 45 mg/mL / mineral oil, light 10 mg/mL Ophthalmic Solution [Soothe Mineral Oil] 	3; 13.5 mg; mg
+24208-0742-99:	9ts4reh -> fbkqm76	Mineral oil 45 mg/mL / mineral oil, light 10 mg/mL Ophthalmic Solution [Soothe Mineral Oil] 	3; 13.5 mg; mg
+50804-0020-01:	afbd0d8 -> xcbtjxy	Polyethylene glycol 400 4 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	1.6; 1.2 mg; mg
+24208-0503-48:	az194zq -> tekh581	Loteprednol etabonate 0.005 mg/mg Ophthalmic Gel [Lotemax] 	2.5 mg
+00023-4491-05:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00023-4491-30:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00023-5773-05:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00023-5773-30:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00023-6954-05:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00023-6954-30:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00023-7151-60:	bh88605 -> teqh8sr	Carboxymethylcellulose sodium 5 mg/mL / glycerin 10 mg/mL / polysorbate 80 5 mg/mL Ophthalmic Solution 	2; 4; 2 mg; mg; mg
+00078-0911-12:	cdc1dg8 -> pdt6jaj	Lifitegrast 50 mg/mL Ophthalmic Solution [Xiidra] 	10 mg
+00078-0911-94:	cdc1dg8 -> pdt6jaj	Lifitegrast 50 mg/mL Ophthalmic Solution [Xiidra] 	10 mg
+59262-0353-12:	cfvj5k8 -> adbem5k	Apis mellifera and euphrasia stricta and schoenocaulon officinale seed 6.0; 6.0; 6 [HP_X]; [HP_X]; [HP_X] Vial [Allergy Eye Relief] 	6; 6; 6 [HP_X]; [HP_X]; [HP_X]
+65302-0062-05:	dcx7ame -> hpgqtf4	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+24208-0495-30:	eb3v25d -> ddvxm8z	Glycerin 6 mg/mL / propylene glycol 6 mg/mL Ophthalmic Solution [Soothe Lubricant Eye Drops] 	3.6; 3.6 mg; mg
+17478-0189-24:	ef2hqg2 -> 7emy8yr	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	1.5 mg
+69918-0601-60:	ef2hqg2 -> 7emy8yr	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	1.5 mg
+00065-0419-18:	fnmek46 -> g76fchk	Dextran 70 1 mg/mL / hypromellose 3 mg/mL Ophthalmic Solution [Tears Naturale] 	0.4; 1.2 mg; mg
+00065-8063-01:	fnmek46 -> mfkd3xe	Dextran 70 1 mg/mL / hypromellose 3 mg/mL Ophthalmic Solution [Tears Naturale] 	1; 2.7 mg; mg
+00065-9305-01:	fnmek46 -> g76fchk	Dextran 70 1 mg/mL / hypromellose 3 mg/mL Ophthalmic Solution [Tears Naturale] 	0.4; 1.2 mg; mg
+00363-0646-01:	fnmek46 -> g76fchk	Dextran 70 1 mg/mL / hypromellose 3 mg/mL Ophthalmic Solution [Tears Naturale] 	0.4; 1.2 mg; mg
+69842-0474-01:	fnmek46 -> g76fchk	Dextran 70 1 mg/mL / hypromellose 3 mg/mL Ophthalmic Solution [Tears Naturale] 	0.4; 1.2 mg; mg
+00078-0743-96:	ggj0t5h -> 4kh3ckj	Nepafenac 3 mg/mL Ophthalmic Suspension [Ilevro] 	2.4 mg
+24208-0600-01:	gpb7y9a -> q3drs07	Ketotifen 0.25 mg/mL Ophthalmic Solution [Alaway] 	0.1 mg
+24208-0600-99:	gpb7y9a -> q3drs07	Ketotifen 0.25 mg/mL Ophthalmic Solution [Alaway] 	0.1 mg
+00187-1496-05:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+00187-1496-99:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+24208-0496-05:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+24208-0499-00:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+24208-0499-68:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+50742-0288-60:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+72485-0602-60:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+82260-0496-05:	gqyeem6 -> jyrtzt3	Preservative-Free timolol 5 mg/mL Ophthalmic Solution [Timoptic] 	2.04 mg
+24208-0537-01:	hmrkv67 -> f1de69e	Brimonidine tartrate 0.25 mg/mL Ophthalmic Solution [Lumify] 	0.1 mg
+24208-0537-10:	hmrkv67 -> f1de69e	Brimonidine tartrate 0.25 mg/mL Ophthalmic Solution [Lumify] 	0.1 mg
+17478-0604-30:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+42571-0382-27:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+42571-0382-73:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+50383-0261-61:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+50742-0323-60:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+65862-0947-18:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+65862-0947-60:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+82584-0604-30:	hr82d5g -> ettajde	Preservative-Free dorzolamide 20 mg/mL / timolol 5 mg/mL Ophthalmic Solution [Cosopt] 	4; 1 mg; mg
+00023-4554-05:	k97qqaw -> 8r2p8v8	Carboxymethylcellulose sodium 0.01 mg/mg Ophthalmic Gel [TheraTears] 	4 mg
+00023-4554-30:	k97qqaw -> 8r2p8v8	Carboxymethylcellulose sodium 0.01 mg/mg Ophthalmic Gel [TheraTears] 	4 mg
+50268-0065-30:	k97qqaw -> 8r2p8v8	Carboxymethylcellulose sodium 0.01 mg/mg Ophthalmic Gel [TheraTears] 	4 mg
+58790-0002-28:	k97qqaw -> q1m5vfr	Carboxymethylcellulose sodium 0.01 mg/mg Ophthalmic Gel [TheraTears] 	6 mg
+58790-0003-30:	k97qqaw -> q1m5vfr	Carboxymethylcellulose sodium 0.01 mg/mg Ophthalmic Gel [TheraTears] 	6 mg
+10742-8161-01:	kmt2nr2 -> hqvqx61	Povidone 6.8 mg/mL / propylene glycol 3 mg/mL Ophthalmic Solution 	3.4; 1.5 mg; mg
+42126-6100-01:	krkggdb -> 84v19j7	Glycerin 2 mg/mL Ophthalmic Solution [Oasis Tears] 	0.66 mg
+42126-6100-02:	krkggdb -> 84v19j7	Glycerin 2 mg/mL Ophthalmic Solution [Oasis Tears] 	0.66 mg
+42126-6200-01:	krkggdb -> 84v19j7	Glycerin 2 mg/mL Ophthalmic Solution [Oasis Tears] 	0.66 mg
+42126-6200-02:	krkggdb -> 84v19j7	Glycerin 2 mg/mL Ophthalmic Solution [Oasis Tears] 	0.66 mg
+24208-0006-30:	kwy4bha -> trvcr16	Glycerin 5 mg/mL Ophthalmic Solution [Regener-Eyes] 	1.5 mg
+69183-0200-00:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+69183-0200-02:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+69183-0200-04:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+69183-0200-08:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+69183-0200-32:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+69183-0200-52:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+69183-0200-72:	m8rd8g3 -> a13enk5	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Eyes Alive Lubricating] 	3 mg
+00023-9163-12:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+00023-9163-30:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+00023-9163-60:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+00378-8760-58:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+00378-8760-91:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+10702-0808-03:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+10702-0808-06:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+60505-6202-01:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+60505-6202-02:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+68180-0214-30:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+68180-0214-60:	mfw5d1d -> 586065t	0.4 mL cyclosporine 0.5 mg/mL Ophthalmic Suspension [Restasis] 	0.2 mg
+24208-0507-01:	mn4zz58 -> tamvfn8	Loteprednol etabonate 0.0038 mg/mg Ophthalmic Gel [Lotemax] 	2 mg
+69918-0602-60:	ng9ecx3 -> c0mfy4k	Preservative-Free timolol 2.5 mg/mL Ophthalmic Solution [Timoptic] 	0.75 mg
+00023-3507-05:	pbwyr3s -> h1dyb33	Ketorolac tromethamine 4.5 mg/mL Ophthalmic Solution [Acuvail] 	1.8 mg
+00023-3507-31:	pbwyr3s -> h1dyb33	Ketorolac tromethamine 4.5 mg/mL Ophthalmic Solution [Acuvail] 	1.8 mg
+40171-0005-05:	pjy8vk4 -> nqry8n1	Polyethylene glycol 400 2.5 mg/mL Ophthalmic Solution [Blink Tears] 	1 mg
+40171-0005-25:	pjy8vk4 -> nqry8n1	Polyethylene glycol 400 2.5 mg/mL Ophthalmic Solution [Blink Tears] 	1 mg
+40171-0005-36:	pjy8vk4 -> nqry8n1	Polyethylene glycol 400 2.5 mg/mL Ophthalmic Solution [Blink Tears] 	1 mg
+00023-4515-30:	pxpkpz9 -> bg2cv2h	Carboxymethylcellulose sodium and glycerin 2.0; 4 mg; mg Vial [Refresh Relieva Pf] 	2; 4 mg; mg
+00023-9537-05:	pxpkpz9 -> bg2cv2h	Carboxymethylcellulose sodium and glycerin 2.0; 4 mg; mg Vial [Refresh Relieva Pf] 	2; 4 mg; mg
+73687-0062-25:	q3f9h7j -> 1emdp5d	Oxymetazoline HCl 1 mg/mL Ophthalmic Solution [Upneeq] 	0.3 mg
+73687-0062-32:	q3f9h7j -> 1emdp5d	Oxymetazoline HCl 1 mg/mL Ophthalmic Solution [Upneeq] 	0.3 mg
+73687-0062-34:	q3f9h7j -> 1emdp5d	Oxymetazoline HCl 1 mg/mL Ophthalmic Solution [Upneeq] 	0.3 mg
+73687-0062-45:	q3f9h7j -> 1emdp5d	Oxymetazoline HCl 1 mg/mL Ophthalmic Solution [Upneeq] 	0.3 mg
+73687-0062-68:	q3f9h7j -> 1emdp5d	Oxymetazoline HCl 1 mg/mL Ophthalmic Solution [Upneeq] 	0.3 mg
+70290-0120-01:	q6q6zvt -> 8w7p1f	Chlorhexidine gluconate and propylene glycol 0.01; 0.02 KG; KG Bottle [Eyewash Station Additive Concentrate] 	0.01; 0.02 KG; KG
+00781-6184-87:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+17478-0609-10:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+17478-0609-30:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+42571-0264-26:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+42571-0264-73:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+42571-0264-74:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+66993-0429-30:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+82584-0609-30:	qtw5nhx -> vaj5y14	Tafluprost 0.015 mg/mL Ophthalmic Solution [Zioptan] 	0 mg
+24208-0040-01:	r7hdy2p -> x2xbd6h	0.9 mL triamcinolone acetonide 40 mg/mL Vial [Xipere] 	36 mg
+24208-0040-40:	r7hdy2p -> x2xbd6h	0.9 mL triamcinolone acetonide 40 mg/mL Vial [Xipere] 	36 mg
+71565-0040-01:	r7hdy2p -> x2xbd6h	0.9 mL triamcinolone acetonide 40 mg/mL Vial [Xipere] 	36 mg
+71565-0040-99:	r7hdy2p -> x2xbd6h	0.9 mL triamcinolone acetonide 40 mg/mL Vial [Xipere] 	36 mg
+47682-0193-83:	savxecv -> 3favyp9	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+47682-0194-83:	savxecv -> 3favyp9	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+55651-0030-01:	savxecv -> 3favyp9	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+73141-0001-01:	savxecv -> bxp2rf3	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	3 mg
+73141-0001-02:	savxecv -> bxp2rf3	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	3 mg
+73141-0001-03:	savxecv -> bxp2rf3	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	3 mg
+73141-0001-04:	savxecv -> bxp2rf3	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	3 mg
+73141-0001-05:	savxecv -> bxp2rf3	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	3 mg
+66051-0236-80:	se20ebd -> w91gtbc	Water and propylene glycol 0.02; 0.2 KG; L Bottle [Eyewash Additive Concentrate] 	0.02; 0.2 KG; L
+53799-0300-12:	snp1845 -> s55sqne	Atropa belladonna and euphrasia stricta and mercuric chloride 6.0; 6.0; 15 [HP_X]; [HP_X]; [HP_X] Vial [Dry Eye Relief] 	6; 6; 15 [HP_X]; [HP_X]; [HP_X]
+59262-0375-12:	snp1845 -> s55sqne	Atropa belladonna and euphrasia stricta and mercuric chloride 6.0; 6.0; 15 [HP_X]; [HP_X]; [HP_X] Vial [Dry Eye Relief] 	6; 6; 15 [HP_X]; [HP_X]; [HP_X]
+24208-0965-01:	v7m0pm1 -> ez5bgm9	Atropine sulfate 10 mg/mL Ophthalmic Solution [Atropine-Care] 	4 mg
+82260-0001-01:	v7m0pm1 -> ez5bgm9	Atropine sulfate 10 mg/mL Ophthalmic Solution [Atropine-Care] 	4 mg
+53799-0305-11:	vbvr5tj -> fapx6rp	Conium maculatum flowering top, graphite and sulfur 6.0; 12.0; 12 [HP_X]; [HP_X]; [HP_X] Bottle [Stye Eye Relief] 	6; 12; 12 [HP_X]; [HP_X]; [HP_X]
+53799-0404-11:	vbvr5tj -> fapx6rp	Graphite, sulfur, conium maculatum 6.0; 12.0; 12 [HP_C]; [HP_C]; [HP_C] Bottle [Walgreens Stye Eye Relief] 	6; 12; 12 [HP_C]; [HP_C]; [HP_C]
+65086-0001-05:	vtnny23 -> gtr0738	Cyclosporine 1 mg/mL Ophthalmic Suspension [Verkazia] 	0.3 mg
+65086-0001-12:	vtnny23 -> gtr0738	Cyclosporine 1 mg/mL Ophthalmic Suspension [Verkazia] 	0.3 mg
+00065-1530-01:	w8ewq1w -> y964qxr	Propylene glycol 6 mg/mL Ophthalmic Solution 	0.03 mg
+00023-0506-01:	wghj6j9 -> rtqh1db	Polyvinyl alcohol 0.014 mL/mL / povidone 6 mg/mL Ophthalmic Solution [MiniDrops] 	5.6; 2.4 mg; mg
+00023-0506-50:	wghj6j9 -> rtqh1db	Polyvinyl alcohol 0.014 mL/mL / povidone 6 mg/mL Ophthalmic Solution [MiniDrops] 	5.6; 2.4 mg; mg
+64108-0212-12:	wghj6j9 -> 8hqjrse	Polyvinyl alcohol 0.014 mL/mL / povidone 6 mg/mL Ophthalmic Solution [MiniDrops] 	7; 3 mg; mg
+64108-0212-13:	wghj6j9 -> 8hqjrse	Polyvinyl alcohol 0.014 mL/mL / povidone 6 mg/mL Ophthalmic Solution [MiniDrops] 	7; 3 mg; mg
+00187-1498-25:	xph7394 -> qj4qdgt	Preservative-Free timolol 2.5 mg/mL Ophthalmic Solution [Timoptic] 	1.02 mg
+24208-0498-34:	xph7394 -> qj4qdgt	Preservative-Free timolol 2.5 mg/mL Ophthalmic Solution [Timoptic] 	1.02 mg
+50742-0287-60:	xph7394 -> qj4qdgt	Preservative-Free timolol 2.5 mg/mL Ophthalmic Solution [Timoptic] 	1.02 mg
+65923-0657-04:	yfk54ea -> vjnwgk4	Carboxymethylcellulose sodium 5 mg/mL Ophthalmic Solution [Revive Plus] 	2 mg
+58790-0000-00:	ymg72wq -> q8w9myb	Carboxymethylcellulose sodium 2.5 mg/mL Ophthalmic Solution [TheraTears] 	1.5 mg
+58790-0000-30:	ymg72wq -> q8w9myb	Carboxymethylcellulose sodium 2.5 mg/mL Ophthalmic Solution [TheraTears] 	1.5 mg
+58790-0010-30:	ymg72wq -> q8w9myb	Carboxymethylcellulose sodium 2.5 mg/mL Ophthalmic Solution [TheraTears] 	1.5 mg
+00065-0816-02:	yzqcehg -> yh5qxmd	Olopatadine 7 mg/mL Ophthalmic Solution [Pataday] 	3.5 mg
+00924-0159-08:	z4103c9 -> 8w7p1f	Chlorhexidine gluconate and propylene glycol 0.01; 0.02 KG; KG Bottle [Eyewash Station Additive Concentrate] 	0.01; 0.02 KG; KG
+65785-0034-01:	z4103c9 -> 8w7p1f	Chlorhexidine gluconate and propylene glycol 0.01; 0.02 KG; KG Bottle [Eyewash Station Additive Concentrate] 	0.01; 0.02 KG; KG
+78641-0785-63:	z4103c9 -> 8w7p1f	Chlorhexidine gluconate and propylene glycol 0.01; 0.02 KG; KG Bottle [Eyewash Station Additive Concentrate] 	0.01; 0.02 KG; KG
+00363-8831-22:	zh4w17a -> pnth500	Mineral oil 5 mg/mL / mineral oil, light 5 mg/mL Ophthalmic Solution 	2; 2 mg; mg
+54799-0917-30:	zh4w17a -> pnth500	Mineral oil 5 mg/mL / mineral oil, light 5 mg/mL Ophthalmic Solution 	2; 2 mg; mg
+53799-0376-13:	zn81xrk -> gv8pat4	Belladonna, euphrasia officinalis, mercurius sublimatus, 0.24; 0.24; 0.6 [HP_X]; [HP_X]; [HP_X] Vial [Dry Eye Relief Trial Size 15X] 	0.24; 0.24; 0.6 [HP_X]; [HP_X]; [HP_X]
+59262-0376-13:	zn81xrk -> gv8pat4	Belladonna, euphrasia officinalis, mercurius sublimatus, 0.24; 0.24; 0.6 [HP_X]; [HP_X]; [HP_X] Vial [Dry Eye Relief Trial Size 15X] 	0.24; 0.24; 0.6 [HP_X]; [HP_X]; [HP_X]
+42571-0398-71:	zsbr7e5 -> q835g8z	24 HR timolol 5 mg/mL Ophthalmic Solution [Istalol] 	2.04 mg
+71776-0024-01:	zta30nf -> xm0bk6s	Cetirizine 2.4 mg/mL Ophthalmic Solution [Zerviate] 	0.48 mg
+71776-0024-30:	zta30nf -> xm0bk6s	Cetirizine 2.4 mg/mL Ophthalmic Solution [Zerviate] 	0.48 mg
+71776-0001-03:	zxefd2j -> m7hs10m	Polyvinyl alcohol 27 mg/mL / povidone 20 mg/mL Ophthalmic Solution [Freshkote] 	8.1; 6 mg; mg
+51206-0202-04:	1ncg45a -> bhbpykg	Benzocaine 0.2 mg/mg Oral Gel [Ultracare] 	80 mg
+51206-0202-05:	1ncg45a -> bhbpykg	Benzocaine 0.2 mg/mg Oral Gel [Ultracare] 	80 mg
+68599-4681-03:	1qmh595 -> 88rtrfr	Acetaminophen 500 mg Oral Tablet [Fanalgic] 	250 mg
+50580-0209-02:	7e1g87c -> g1kcm5n	Acetaminophen 500 mg Oral Powder [Tylenol] 	500 mg
+50580-0209-04:	7e1g87c -> g1kcm5n	Acetaminophen 500 mg Oral Powder [Tylenol] 	500 mg
+60306-0115-05:	8eadbkn -> wxd1e52	Benzocaine 0.09 mg/mg Oral Gel [Brace Relief] 	2.7 mg
+81417-0001-01:	b829xyq -> kkrehhs	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	150 mg
+61010-8100-01:	gdmws38 -> nn34k9e	Benzocaine 200 mg/mL Oral Cream 	150 mg
+61010-8100-02:	m7b3pww -> 4w51c0h	Benzocaine 200 mg/mL Oral Cream 	100 mg
+68094-0045-58:	pd3aw5v -> p1p7hjf	Morphine sulfate 20 mg/mL Oral Solution [MSIR] 	10 mg
+68094-0056-58:	pd3aw5v -> p1p7hjf	Morphine sulfate 20 mg/mL Oral Solution [MSIR] 	10 mg
+70166-0101-02:	pd3aw5v -> ag30a0j	Morphine sulfate 20 mg/mL Oral Solution [MSIR] 	2.5 mg
+70166-0101-05:	pd3aw5v -> pt8aaq1	Morphine sulfate 20 mg/mL Oral Solution [MSIR] 	5 mg
+70166-0101-10:	pd3aw5v -> p1p7hjf	Morphine sulfate 20 mg/mL Oral Solution [MSIR] 	10 mg
+17856-0392-01:	q8yv45r -> 2qc33x6	Methadone HCl 10 mg/mL Oral Solution [Methadose] 	5 mg
+17856-1928-05:	q8yv45r -> 2qc33x6	Methadone HCl 10 mg/mL Oral Solution [Methadose] 	5 mg
+17856-1928-06:	q8yv45r -> pfqca3j	Methadone HCl 10 mg/mL Oral Solution [Methadose] 	2.5 mg
+17856-0023-01:	qrh5kjj -> vgn7m6t	Oxycodone HCl 20 mg/mL Oral Solution [Oxydose] 	10 mg
+17856-0023-02:	qrh5kjj -> p9r8h1x	Oxycodone HCl 20 mg/mL Oral Solution [Oxydose] 	2.5 mg
+17856-0023-05:	qrh5kjj -> hwm3w83	Oxycodone HCl 20 mg/mL Oral Solution [Oxydose] 	5 mg
+17856-0023-06:	qrh5kjj -> hwm3w83	Oxycodone HCl 20 mg/mL Oral Solution [Oxydose] 	5 mg
+64950-0353-51:	qrh5kjj -> vgn7m6t	Oxycodone HCl 20 mg/mL Oral Solution [Oxydose] 	10 mg
+68094-0801-58:	qrh5kjj -> vgn7m6t	Oxycodone HCl 20 mg/mL Oral Solution [Oxydose] 	10 mg
+68071-4128-01:	s4thwmf -> 9z2qvaz	Magnesium citrate 58.2 mg/mL Oral Solution [Citroma] 	17.45 mg
+72705-0110-06:	xarvj7k -> f5pt99d	Simethicone 66.7 mg/mL Oral Suspension [Little Tummys] 	20 mg
+72705-0110-10:	xarvj7k -> f5pt99d	Simethicone 66.7 mg/mL Oral Suspension [Little Tummys] 	20 mg
+00283-0293-59:	xy7x13j -> 8f09a64	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	100 mg
+00283-0871-59:	xy7x13j -> 8f09a64	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	100 mg
+00283-0886-59:	xy7x13j -> 8f09a64	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	100 mg
+00283-0998-59:	xy7x13j -> 8f09a64	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	100 mg
+00283-1016-59:	xy7x13j -> 8f09a64	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	100 mg
+55670-0810-01:	xy7x13j -> kkrehhs	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	150 mg
+68599-8247-04:	xy7x13j -> kkrehhs	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	150 mg
+81417-0121-01:	xy7x13j -> kkrehhs	Benzocaine 0.2 mg/mg Oral Gel [Gingicaine] 	150 mg
+42195-0128-14:	11garjp -> zjr08m6	Ciprofloxacin 3 mg/mL / fluocinolone acetonide 0.25 mg/mL Otic Solution [Otovel] 	0.75; 0.06 mg; mg
+66992-0128-14:	11garjp -> zjr08m6	Ciprofloxacin 3 mg/mL / fluocinolone acetonide 0.25 mg/mL Otic Solution [Otovel] 	0.75; 0.06 mg; mg
+42195-0550-14:	mrhcp47 -> h5tby64	Ciprofloxacin 2 mg/mL Otic Solution [Cetraxal] 	0.5 mg
+66992-0450-14:	mrhcp47 -> h5tby64	Ciprofloxacin 2 mg/mL Otic Solution [Cetraxal] 	0.5 mg
+82957-0101-11:	4e1cj2a -> jww6br5	Salicylic acid 0.5% 12.5 mg Patch [Laboflex Acne Spot Care] 	12.5 mg
+72630-0020-02:	8wf7xay -> 7zfyxf5	Sodium hyaluronate, niacinamide, adenosine 0.2; 210.0; 7 mg; mg; mg Patch [Dr.Plinus Fillincell Multi] 	0.2; 210; 7 mg; mg; mg
+71446-0001-01:	c9a8fhk -> p81vs6b	Menthol 250 mg Patch [Dr Tans Arthritis Formula 3 Day Patch] 	250 mg
+71446-0002-01:	q9vda87 -> dmh0ckj	Peppermint 90 mg Patch [Dr Tans Pain Releiving 3 Day Herabl Patch] 	90 mg
+72630-0040-02:	vaw6wkh -> skjcag9	Niacinamide, adenosine 0.12; 6 mg; mg Patch [Dr.Plinus Fillincell Multi Ex] 	0.12; 6 mg; mg
+72630-0040-03:	vaw6wkh -> skjcag9	Niacinamide, adenosine 0.12; 6 mg; mg Patch [Dr.Plinus Fillincell Multi Ex] 	0.12; 6 mg; mg
+00220-1351-41:	5khqz51 -> x03bmfr	Artemisia cina pre-flowering top 1 [HP_M]/[HP_M] [Hp_M] [Cina] 	1 [HP_M]/[HP_M]
+00220-1374-41:	5khqz51 -> x03bmfr	Artemisia cina pre-flowering top 1 [HP_C]/[HP_C] [Hp_C] [Cina] 	1 [HP_C]/[HP_C]
+15631-0137-00:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-01:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-02:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-03:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-04:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-05:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-06:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+15631-0137-07:	5khqz51 -> x03bmfr	Cina 1 [HP_X] Pellet 	1 [HP_X]
+37662-0320-01:	5khqz51 -> x03bmfr	Cina 1 [HP_M] Pellet 	1 [HP_M]
+37662-0320-02:	5khqz51 -> x03bmfr	Cina 1 [HP_M] Pellet 	1 [HP_M]
+37662-0320-03:	5khqz51 -> x03bmfr	Cina 1 [HP_M] Pellet 	1 [HP_M]
+37662-0320-04:	5khqz51 -> x03bmfr	Cina 1 [HP_M] Pellet 	1 [HP_M]
+00220-1063-41:	vk0fyhf -> qrz9qa0	Calendula officinalis flowering top 1 [HP_C]/[HP_C] [Hp_C] [Calendula Officinalis] 	1 [HP_C]/[HP_C]
+00220-1066-41:	vk0fyhf -> qrz9qa0	Calendula officinalis flowering top 1 [HP_C]/[HP_C] [Hp_C] [Calendula Officinalis] 	1 [HP_C]/[HP_C]
+15631-0101-00:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-01:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-02:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-03:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-04:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-05:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-06:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+15631-0101-07:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_X] Pellet 	1 [HP_X]
+37662-0149-01:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_M] Pellet 	1 [HP_M]
+37662-0149-02:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_M] Pellet 	1 [HP_M]
+37662-0149-03:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_M] Pellet 	1 [HP_M]
+37662-0149-04:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_M] Pellet 	1 [HP_M]
+37662-0151-01:	vk0fyhf -> qrz9qa0	Calendula officinalis 1 [HP_Q] Pellet 	1 [HP_Q]
+98132-0894-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0895-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0896-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0897-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0898-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0899-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0900-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0901-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0905-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0906-75:	5npapt5 -> bk70g6a	Titanium dioxide 187.5 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	187.5 mg
+98132-0231-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0232-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0233-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0234-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0235-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0236-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0237-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0238-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0239-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0240-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0241-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0242-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0243-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0244-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0245-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0246-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0247-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0248-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0249-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+98132-0250-03:	bcarjsw -> y1ra1p9	Salicylic acid 3.75 mg Jar [Bareminerals Blemish Rescue Skin-Clearing Loose Foundation] 	3.75 mg
+37000-0024-04:	dr13v32 -> qhm40t0	Psyllium husk 12.31 mg Pouch [Metamucil] 	12.31 mg
+98132-0008-01:	e4m10p6 -> 6avv5wq	Titanium dioxide and zinc oxide 120.0; 75 mg; mg Jar [Bareminerals Multi-Tasking Spf 20 Concealer] 	120; 75 mg; mg
+98132-0021-75:	n7pjgs4 -> d8kgx4d	Titanium dioxide and zinc oxide 52.5; 150 mg; mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	52.5; 150 mg; mg
+98132-0022-75:	n7pjgs4 -> d8kgx4d	Titanium dioxide and zinc oxide 52.5; 150 mg; mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	52.5; 150 mg; mg
+37000-0024-10:	p6qbd3s -> qhm40t0	Psyllium husk 12.31 mg Pouch [Metamucil] 	12.31 mg
+98132-0026-75:	t8yz373 -> 8ykw3db	Zinc oxide 150 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	150 mg
+98132-0027-75:	t8yz373 -> 8ykw3db	Zinc oxide 150 mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	150 mg
+98132-0019-75:	z1najcb -> save1w5	Titanium dioxide and zinc oxide 87.75; 150 mg; mg Jar [Bareminerals Original Foundation Broad Spectrum Spf 15] 	87.75; 150 mg; mg
+66490-0650-20:	ww6pyyw -> 981700k	0.5 mL diazepam 5 mg/mL Rectal Gel [Diastat] 	2.5 mg
+68682-0650-20:	ww6pyyw -> 981700k	0.5 mL diazepam 5 mg/mL Rectal Gel [Diastat] 	2.5 mg
+30142-0153-35:	e71ek3p -> 7mjd5wj	Zinc pyrithione 10 mg/mL Medicated Shampoo [Pert Plus Dandruff] 	0.01 KG
+30142-0153-15:	vtzvrcw -> 9yyvxgw	Zinc pyrithione 10 mg/mL Medicated Shampoo [Pert Plus Dandruff] 	0 KG
+36800-0153-15:	vtzvrcw -> 9yyvxgw	Zinc pyrithione 10 mg/mL Medicated Shampoo [Pert Plus Dandruff] 	0 KG
+36800-0153-21:	zmvm9h9 -> 7mjd5wj	Zinc pyrithione 10 mg/mL Medicated Shampoo [Pert Plus Dandruff] 	0.01 KG
+64009-0335-82:	3705ptr -> pyqxc6s	Chloroxylenol 10 mg/mL Medicated Liquid Soap [DermaFoam E] 	5378.52 mg
+00404-4441-01:	3yzafbs -> v4rxcj8	Chloroxylenol 6 mg/mL Medicated Liquid Soap [Clean Force Antibacterial] 	3325.3 mg
+64009-0332-72:	47f3ax1 -> wm4n7ce	Benzalkonium chloride 1.3 mg/mL Topical Foam [Lite 'N Foamy] 	691.6 mg
+62476-0102-38:	5gacrj5 -> 7keezzx	Benzalkonium chloride 0.1% 100 mg Cello Pack [Jabon Cremoso] 	100 mg
+65585-0373-03:	5gy6ed6 -> zpwwgkq	Ethanol 0.65 mL/mL Topical Foam 	325 mL
+65585-0373-07:	5gy6ed6 -> 7dnhxqp	Ethanol 0.65 mL/mL Topical Foam 	32.5 mL
+64009-0331-82:	6wb0jcs -> jnf5x03	Benzalkonium chloride 1 mg/mL Topical Foam [Lite 'N Foamy] 	532 mg
+11084-0010-01:	8adeh1h -> 92erskm	Benzalkonium chloride 1.3 mg/mL Medicated Liquid Soap [Nobac] 	6.11 mg
+62569-0000-01:	94b1qnq -> g1jzk5d	Chloroxylenol 2.5 mg/mL Medicated Liquid Soap 	1330 mg
+61666-0901-23:	bjtwhvn -> arycegw	Chloroxylenol 2.5 mg/mL Medicated Liquid Soap 	1175 mg
+65585-0374-06:	d5zd9nz -> sxq05ws	Ethanol 0.62 mL/mL Topical Foam 	31 mL
+62476-0102-15:	g006ydn -> k62z56x	Benzalkonium chloride 0.1% 400 mg Cello Pack [Jabon Cremoso] 	400 mg
+67777-0319-01:	k7s9cp8 -> 3qgf9de	Benzalkonium chloride 1.3 mg/mL Medicated Liquid Soap [Nobac] 	0.17 mg
+00404-4438-01:	kq5062b -> 9phzvme	Chloroxylenol 6 mg/mL Medicated Liquid Soap [Clean Force Antibacterial] 	2885.3 mg
+65585-0373-06:	pcp4rc0 -> 7dnhxqp	Ethanol 0.65 mL/mL Topical Foam 	32.5 mL
+11084-0010-96:	q9mkb3p -> 4b6yav0	Benzalkonium chloride 1.3 mg/mL Medicated Liquid Soap [Nobac] 	38.48 mg
+65585-0519-02:	sye5css -> 4cfqgtg	Ethanol 0.6 mL/mL Topical Gel 	142.2 mL
+65585-0374-03:	w9ftz45 -> 7s2b4mn	Ethanol 0.62 mL/mL Topical Foam 	341 mL
+65585-0374-07:	w9ftz45 -> sxq05ws	Ethanol 0.62 mL/mL Topical Foam 	31 mL
+00404-4438-02:	xqqtffe -> r6cq82c	Chloroxylenol 6 mg/mL Medicated Liquid Soap [Clean Force Antibacterial] 	1445.7 mg
+11084-0010-40:	z0q0575 -> a8vkys5	Benzalkonium chloride 1.3 mg/mL Medicated Liquid Soap [Nobac] 	52 mg
+65174-0880-25:	4ega40s -> zshys8z	Sodium iodide i 131 250 MCI Vial [Hicon] 	250 MCI
+65174-0880-50:	4ega40s -> 3ydj2f3	Sodium iodide i 131 500 MCI Vial [Hicon] 	500 MCI
+52261-8700-01:	4wv26az -> 9pxatpp	Alcohol 0.04 L Bottle [Lululemon Selfcare No Nasties Hand Sanitizer] 	0.04 L
+52261-8700-02:	4wv26az -> w5z1wew	Alcohol 0.35 L Bottle [Lululemon Selfcare No Nasties Hand Sanitizer] 	0.35 L
+10129-0002-03:	62cb9xk -> xahkmvs	Dl epinephrine hci 0.02 mg/MM Mm [Gingi-Pak Max Soft-Twist No 2] 	0.02 mg/MM
+50458-0028-02:	6m7k4mf -> 1qegxxc	Esketamine HCl 28 mg Pack [Spravato] 	28 mg
+50458-0028-03:	6m7k4mf -> 1qegxxc	Esketamine HCl 28 mg Pack [Spravato] 	28 mg
+49967-0635-02:	abfk6ck -> 10v01fa	Alcohol 0.08 L Bottle [Saloncentric Antiseptic Hand Sanitizer] 	0.08 L
+49967-0635-01:	c53mzvz -> zjeef4x	Alcohol 0.2 L Bottle [Saloncentric Antiseptic Hand Sanitizer] 	0.2 L
+80194-0101-02:	c5v9gbb -> 5jb7kd4	Alcohol 0.17 L Package [Sda 40B] 	0.17 L
+80194-0116-02:	c5v9gbb -> 5jb7kd4	Alcohol 0.17 L Package [Sda 40B] 	0.17 L
+52380-4111-02:	jqxtrdf -> y7bd727	Povidone-iodine 5 mg Packet [Aplicare Povidone-Iodine Prep Pad] 	5 mg
+42961-0022-02:	bt3easy -> 12ehbc5	Antiseptic cleanser 0.13 mg Packet [Xpect Antiseptic Wipes] 	0.13 mg
+42961-0022-03:	bt3easy -> 12ehbc5	Antiseptic cleanser 0.13 mg Packet [Xpect Antiseptic Wipes] 	0.13 mg
+72247-0101-12:	hxe8fx5 -> zcc9ynq	Sodium fluoride 0.02 mg Cylinder [Curodont Repair Fluoride Plus] 	0.02 mg
+42961-0018-02:	hy3rej7 -> fhzv8e0	Alcohol wipes 0.7  Packet [Zee Medical Clean Wipes] 	0.7 nan
+42961-0057-02:	sf1pdxb -> 4wqajgd	Alcohol wipes 0.7 mL Packet [Zee Clean Wipes] 	0.7 mL
+42961-0057-03:	sf1pdxb -> 4wqajgd	Alcohol wipes 0.7 mL Packet [Zee Clean Wipes] 	0.7 mL
+42961-0057-04:	sf1pdxb -> 4wqajgd	Alcohol wipes 0.7 mL Packet [Zee Clean Wipes] 	0.7 mL
+42961-0226-02:	sf1pdxb -> 4wqajgd	Alcohol wipes 0.7 mL Packet [Xpect Alcohol Wipes] 	0.7 mL
+42961-0226-03:	sf1pdxb -> 4wqajgd	Alcohol wipes 0.7 mL Packet [Xpect Alcohol Wipes] 	0.7 mL
+72252-0515-04:	3wnqzj2 -> hsyxgtj	Diazepam 7.5 mg Pack [Valtoco] 	7.5 mg
+61010-8201-00:	6b4y68t -> 2ghfekh	Menthol 4.13 mg Bottle [Analgesic] 	4.13 mg
+47682-0259-02:	7y3qb4w -> rd730fp	Hydrogen peroxide 2557.55 mg Bottle [Medi-First Hydrogen Peroxide] 	2557.55 mg
+47682-0275-02:	7y3qb4w -> rd730fp	Hydrogen peroxide 2557.55 mg Bottle [Medi-First Hydrogen Peroxide] 	2557.55 mg
+47682-0235-02:	9nzwv1e -> 5ywj6sh	Analgesic- menthol 4.13 mg Bottle [Medi-First Pain Relief] 	4.13 mg
+73408-0268-02:	c6wmcv3 -> cpj0cpy	Isopropyl alcohol 32516.82 mg Bottle [Crane Safety Isopropyl Alcohol] 	32516.82 mg
+73408-0257-02:	dcyy28a -> 9x3q844	Hydrogen peroxide 2557.55 mg Bottle [Crane Safety Hydrogen Peroxide] 	2557.55 mg
+69103-5300-00:	f5y5z9j -> zk64hke	Benzalkonium chloride, benzocaine 59.1; 2718.6 mg; mg Bottle [Antiseptic] 	59.1; 2718.6 mg; mg
+72252-0510-02:	g8z2qb9 -> n6d9d6r	Diazepam 10 mg Vial [Valtoco] 	10 mg
+72252-0520-04:	g8z2qb9 -> n6d9d6r	Diazepam 10 mg Vial [Valtoco] 	10 mg
+69968-0543-03:	jmxjx45 -> c66vrg8	Avobenzone, homosalate, octisalate, and octocrylene 3000.0; 10000.0; 5000.0; 10000 mg; mg; mg; mg Bottle [Neutrogena Ultra Sheer Face Mist Sunscreen Broad Spectrum Spf 55] 	3000; 10000; 5000; 10000 mg; mg; mg; mg
+69968-0685-03:	jmxjx45 -> c66vrg8	Avobenzone, homosalate, octisalate, and octocrylene 3000.0; 10000.0; 5000.0; 10000 mg; mg; mg; mg Bottle [Neutrogena Invisible Daily Defense Face Mist Sunscreen Broad Spectrum Spf 50] 	3000; 10000; 5000; 10000 mg; mg; mg; mg
+72252-0505-02:	qn889w7 -> r67p5vp	Diazepam 5 mg Pack [Valtoco] 	5 mg
+58411-0667-20:	e0fznqh -> m2xgqer	Titanium dioxide 80 mg Cartridge [Cle De Peau Beaute Concealer N] 	80 mg
+37808-0337-89:	q4gb14a -> 154y7en	Avobenzone, homosalate, octisalate, octocrylene 4.5; 15.0; 7.5; 7.5 mg; mg; mg; mg Container [Heb Broad Spectrum Spf 30 Pomegranate Scented Sunscreen Lip Balm] 	4.5; 15; 7.5; 7.5 mg; mg; mg; mg
+37808-0930-89:	qwrfrd2 -> rfjj830	Avobenzone, homosalate, octisalate, octocrylene 4.5; 15.0; 7.5; 7.5 mg; mg; mg; mg Container [Heb Broad Spectrum Spf 30 Mango Scented Sunscreen] 	4.5; 15; 7.5; 7.5 mg; mg; mg; mg
+37808-0931-89:	qwrfrd2 -> rfjj830	Avobenzone, homosalate, octisalate, octocrylene 4.5; 15.0; 7.5; 7.5 mg; mg; mg; mg Container [Heb Broad Spectrum Spf 30 Coconut Scented Sunscreen] 	4.5; 15; 7.5; 7.5 mg; mg; mg; mg
+37808-0933-89:	qwrfrd2 -> rfjj830	Avobenzone, homosalate, octisalate, octocrylene 4.5; 15.0; 7.5; 7.5 mg; mg; mg; mg Container [Heb Broad Spectrum Spf 30 Banana Scented Sunscreen] 	4.5; 15; 7.5; 7.5 mg; mg; mg; mg
+11822-6035-09:	gbz8mxz -> apfkped	Benzocaine 50 mg Blister Pack [Rite Aid Tooth And Gum Pain Relief] 	50 mg
+17856-0799-01:	rpspr7f -> fw5kc1r	Simethicone 20 mg Syringe [Mylicon] 	20 mg
+17856-0799-02:	rpspr7f -> fw5kc1r	Simethicone 20 mg Syringe [Mylicon] 	20 mg
+17856-0799-03:	rpspr7f -> 338rxak	Simethicone 40 mg Syringe [Mylicon] 	40 mg
+17856-0799-04:	rpspr7f -> 338rxak	Simethicone 40 mg Syringe [Mylicon] 	40 mg
+49953-2803-01:	4ry7bch -> ws8n5aq	Benzalkonium 0 mg Pouch [Rongbang Bzk Cleansing Pad] 	0 mg
+65517-0039-01:	6xj6xrc -> q7gn0n6	Povidone-iodine 5 mg Applicator [Pvp-I Prep Pads Paper-Foil] 	5 mg
+42339-0003-01:	953zkj2 -> 3yej820	Povidone-iodine 56.58 mg Pouch [Povidone-Iodine Pad] 	56.58 mg
+42339-0003-02:	953zkj2 -> 3yej820	Povidone-iodine 56.58 mg Pouch [Povidone-Iodine Pad] 	56.58 mg
+00498-0121-34:	c6k7q5e -> rkrafxn	Povidone-iodine 10% 3 mg Pouch [Pvp Iodine Wipe] 	3 mg
+47993-0240-02:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-04:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-06:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-08:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-10:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-12:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-14:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-16:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-18:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+47993-0240-20:	gdfsxq9 -> hy5bekx	Anti-frizz sheets 10 mg Pouch 	10 mg
+70888-0001-01:	mrqyyjq -> vmp7s4m	Benzalkonium chloride 0.08 mg Pouch [Antibacterial Wet Wipes] 	0.08 mg
+70888-0001-02:	mrqyyjq -> 3k7zqht	Benzalkonium chloride 0.05 mg Pouch [Antibacterial Wet Wipes] 	0.05 mg
+70888-0001-03:	mrqyyjq -> 3k7zqht	Benzalkonium chloride 0.05 mg Pouch [Antibacterial Wet Wipes] 	0.05 mg
+70888-0001-04:	mrqyyjq -> p1etb7w	Benzalkonium chloride 0.16 mg Pouch [Antibacterial Wet Wipes] 	0.16 mg
+70888-0001-05:	mrqyyjq -> 6hs1sma	Benzalkonium chloride 0.27 mg Pouch [Antibacterial Wet Wipes] 	0.27 mg
+70888-0001-06:	mrqyyjq -> kngbvvq	Benzalkonium chloride 0.44 mg Pouch [Antibacterial Wet Wipes] 	0.44 mg
+70888-0001-07:	mrqyyjq -> 888625d	Benzalkonium chloride 0.55 mg Pouch [Antibacterial Wet Wipes] 	0.55 mg
+70888-0001-08:	mrqyyjq -> 6hs1sma	Benzalkonium chloride 0.27 mg Pouch [Antibacterial Wet Wipes] 	0.27 mg
+70888-0001-09:	mrqyyjq -> kngbvvq	Benzalkonium chloride 0.44 mg Pouch [Antibacterial Wet Wipes] 	0.44 mg
+70888-0001-10:	mrqyyjq -> 888625d	Benzalkonium chloride 0.55 mg Pouch [Antibacterial Wet Wipes] 	0.55 mg
+75213-0001-01:	sg98np6 -> 5449rhb	Benzalkonium chloride,didecyldimonium chloride 0.04; 0.07 mg; mg Pouch [Wet Wipes] 	0.04; 0.07 mg; mg
+75213-0001-02:	sg98np6 -> f5je1v1	Benzalkonium chloride,didecyldimonium chloride 0.1; 0.18 mg; mg Pouch [Wet Wipes] 	0.1; 0.18 mg; mg
+75213-0001-03:	sg98np6 -> nvqz4v4	Benzalkonium chloride,didecyldimonium chloride 0.18; 0.36 mg; mg Pouch [Wet Wipes] 	0.18; 0.36 mg; mg
+75213-0001-04:	sg98np6 -> shqf4wb	Benzalkonium chloride,didecyldimonium chloride 0.36; 0.72 mg; mg Pouch [Wet Wipes] 	0.36; 0.72 mg; mg
+75213-0001-05:	sg98np6 -> xe9tadm	Benzalkonium chloride,didecyldimonium chloride 0.22; 0.43 mg; mg Pouch [Wet Wipes] 	0.22; 0.43 mg; mg
+75213-0001-06:	sg98np6 -> xe9tadm	Benzalkonium chloride,didecyldimonium chloride 0.22; 0.43 mg; mg Pouch [Wet Wipes] 	0.22; 0.43 mg; mg
+75213-0001-07:	sg98np6 -> mz2j0z7	Benzalkonium chloride,didecyldimonium chloride 0.27; 0.54 mg; mg Pouch [Wet Wipes] 	0.27; 0.54 mg; mg
+75213-0001-08:	sg98np6 -> t89829h	Benzalkonium chloride,didecyldimonium chloride 0.3; 0.58 mg; mg Pouch [Wet Wipes] 	0.3; 0.58 mg; mg
+75213-0001-09:	sg98np6 -> shqf4wb	Benzalkonium chloride,didecyldimonium chloride 0.36; 0.72 mg; mg Pouch [Wet Wipes] 	0.36; 0.72 mg; mg
+75213-0001-10:	sg98np6 -> 8njccc7	Benzalkonium chloride,didecyldimonium chloride 0.54; 1.08 mg; mg Pouch [Wet Wipes] 	0.54; 1.08 mg; mg
+69139-0212-01:	sma4y96 -> 2ve6cfg	Alcohol 210 mg Package [Jensil Alcohol Pad] 	210 mg
+69139-0106-01:	w5k6vpg -> qc7b6t3	Benzalkonium chloride 0.6 mg Pouch [Coralite Antibacterial Bandages] 	0.6 mg
+34645-4011-01:	xxkpe72 -> whmkgdm	Povidone-iodine 0.04 mg Pouch [Povidone Iodine Wipe] 	0.04 mg
+72976-0011-01:	xxkpe72 -> whmkgdm	Povidone-iodine 0.04 mg Pouch [Povidone Iodine Wipe] 	0.04 mg
+00363-6500-01:	981t7nq -> jfrrvz7	Candida albicans, wood creosote, sodium chloride, and sulfur 11.25; 4.5; 4.5; 11.25 [HP_X]; [HP_X]; [HP_X]; [HP_X] Blister Pack [Homeopathic Medicine Yeast Relief Plus] 	11.25; 4.5; 4.5; 11.25 [HP_X]; [HP_X]; [HP_X]; [HP_X]
+54973-4080-01:	nyvtgc7 -> gbx9pje	Sodium chloride 6 [HP_X] Tablet [Nat Mur] 	6 [HP_X]
+54973-4080-02:	nyvtgc7 -> gbx9pje	Sodium chloride 6 [HP_X] Tablet [Nat Mur] 	6 [HP_X]
+73729-0845-19:	yrga87g -> jft3rh5	Menthol 12 mg Patch [Myosport Relieve Kinesiology] 	12 mg
+66096-0749-08:	xxv36ss -> rsfncy7	Spongilla lacustris 1 [HP_X] Bottle [Spongilla Lacustris Mt] 	1 [HP_X]
+66096-0750-08:	xxv36ss -> rsfncy7	Psychotria ipecacuanha 1 [HP_X] Bottle [Psychotria Ipecacuanha Mt] 	1 [HP_X]
+66096-0752-08:	xxv36ss -> rsfncy7	Rhus toxicodendron 1 [HP_X] Bottle [Rhus Toxicodendron Mt] 	1 [HP_X]
+00498-0733-00:	14fd527 -> sh83dmk	Ethanol 0.5 mL/mL / lidocaine HCl 20 mg/mL Medicated Pad 	0.2; 8 mL; mg
+49953-1895-02:	17csts7 -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+71734-0346-01:	1kd9n29 -> cvnt63w	Ethanol 0.75 mL/mL Topical Solution 	675 mg
+36800-0804-43:	1kmqya8 -> tfry70k	Isopropyl alcohol 0.91 mL/mL Topical Solution 	0.43 mg
+00498-0801-35:	1yhaw2q -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+52410-3050-02:	1yhaw2q -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+77338-0305-02:	1yhaw2q -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+81649-0030-25:	22d5ah9 -> gz6m9xz	Capsaicin 0.25 mg/mL / menthol 100 mg/mL / methyl salicylate 300 mg/mL Topical Lotion [Dendracin Neurodendraxcin] 	0.06; 25; 75 mg; mg; mg
+00498-0750-36:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00924-5604-00:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+47682-0223-99:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0227-99:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0393-99:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+52410-3025-02:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+69103-5603-01:	25y98en -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+51811-0100-50:	2cadvpt -> 6mawzhj	Ethanol 0.665 mL/mL Topical Spray 	5.32 mL
+77251-0003-01:	2h8rsdh -> 82qxtrg	Ethanol 0.7 mL/mL Topical Gel 	0.18 L
+75269-0011-01:	2mgdp0s -> nwdy8fk	Ethanol 0.75 mL/mL Medicated Pad 	0 mL
+75269-0011-02:	2mgdp0s -> nwdy8fk	Ethanol 0.75 mL/mL Medicated Pad 	0 mL
+83170-0101-15:	2mgdp0s -> pd86p8z	Ethanol 0.75 mL/mL Medicated Pad 	0.38 mL
+64942-1259-01:	2mjwmkh -> v5dc9md	Salicylic acid 20 mg/mL Medicated Pad [Noxzema Clean] 	0.57 mg
+00498-0118-46:	2trgg5r -> zmk4x9y	Povidone-iodine 10 mg/mL Medicated Pad 	6 mg
+00498-0128-46:	2trgg5r -> zmk4x9y	Povidone-iodine 10 mg/mL Medicated Pad 	6 mg
+73744-0267-02:	2yk3fkn -> wbbhc3c	Ethanol 0.7 mL/mL Topical Gel 	0.66 L
+73744-0268-02:	2yk3fkn -> wbbhc3c	Ethanol 0.7 mL/mL Topical Gel 	0.66 L
+74446-0330-32:	2yk3fkn -> wbbhc3c	Ethanol 0.7 mL/mL Topical Gel 	0.66 L
+51811-0400-50:	32kp2vk -> tepm2hx	Ethanol 0.7 mL/mL Topical Gel 	331.1 mg
+51811-0400-51:	32kp2vk -> tepm2hx	Ethanol 0.7 mL/mL Topical Gel 	331.1 mg
+51811-0400-52:	32kp2vk -> tepm2hx	Ethanol 0.7 mL/mL Topical Gel 	331.1 mg
+00404-0121-01:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+00924-8112-01:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+00924-8112-02:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+00924-8112-03:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+10819-3883-01:	3g3m029 -> xhte9r5	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	8 mg
+10819-3888-03:	3g3m029 -> 6sns7ee	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	7.5 mg
+42961-0023-01:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+46414-7777-02:	3g3m029 -> zrk2xym	Povidone-iodine 100 mg/mL Topical Solution [Videne] 	6 mg
+46414-7777-03:	3g3m029 -> zrk2xym	Povidone-iodine 100 mg/mL Topical Solution [Videne] 	6 mg
+47682-0267-12:	3g3m029 -> b6rx7jr	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	3.75 mg
+65517-0034-01:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+65517-0034-02:	3g3m029 -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+67777-0419-04:	3g3m029 -> 75h3q8w	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	9 mg
+67777-0419-11:	3g3m029 -> y0pn6x0	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	3 mg
+73288-0002-01:	3g3m029 -> db56bts	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	6.7 mg
+82996-0006-01:	3g3m029 -> 1b02v1v	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	4.5 mg
+69968-0060-01:	3hynawa -> czjr27x	Bacitracin 0.5 UNT/mg / polymyxin B 10 UNT/mg Topical Ointment [Polysporin] 	450; 9000 [USP'U]; [USP'U]
+68599-9560-01:	4079q8z -> hhrnm1s	Benzocaine 200 mg/mL / menthol 10 mg/mL Medicated Pad [Medicaine Sting] 	4.2; 0.21 mg; mg
+74446-0391-51:	41stam3 -> 7r6zt7d	Ethanol 0.8 mL/mL Topical Solution 	0.05 L
+75205-0258-02:	41stam3 -> 7r6zt7d	Ethanol 0.8 mL/mL Topical Solution 	0.05 L
+78434-0110-02:	41stam3 -> 7r6zt7d	Ethanol 0.8 mL/mL Topical Solution 	0.05 L
+69103-5500-00:	48b76bk -> 1453w2q	Isopropyl alcohol 0.7 mL/mL Topical Spray 	41.37 mL
+71338-0140-02:	48b76bk -> 1453w2q	Isopropyl alcohol 0.7 mL/mL Topical Spray 	41.37 mL
+73288-0003-01:	4ab712y -> wng4rrg	Benzalkonium chloride 4 mg/mL Medicated Pad 	3.4 mg
+77251-0001-08:	4bvnjet -> a1evthn	Ethanol 0.8 mL/mL Topical Solution 	0.14 L
+51811-0100-52:	4h55hqw -> g8epcf4	Ethanol 0.665 mL/mL Topical Spray 	6.65 mL
+73744-0269-05:	4m4w7xm -> az078zm	Isopropyl alcohol 0.7 mL/mL Topical Gel 	0.08 L
+76982-8885-09:	4pf3c2s -> njey5v2	Benzalkonium chloride 10 mg/mL Medicated Pad 	0.46 mg
+61010-5200-04:	4qdntkn -> 715zxe2	Ethanol 0.5 mL/mL / lidocaine HCl 20 mg/mL Medicated Pad 	400; 16 mg; mg
+61010-5200-05:	4qdntkn -> 715zxe2	Ethanol 0.5 mL/mL / lidocaine HCl 20 mg/mL Medicated Pad 	400; 16 mg; mg
+52000-0046-42:	57cx2qq -> sryn3dd	Capsaicin 0.00083 mg/mg / menthol 0.03 mg/mg Medicated Patch 	0.17; 6.18 mg; mg
+00363-0295-16:	5byxe8p -> pf6ta59	Diphenhydramine HCl 20 mg/mL / zinc acetate 1 mg/mL Topical Spray [Wal-Dryl] 	0; 0 KG; KG
+00924-5011-00:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+00924-5702-00:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+42961-0214-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0260-99:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0270-99:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0326-99:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50814-0009-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50814-0059-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+59898-0902-36:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+70897-0001-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+72976-0005-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+72976-0008-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+77338-0100-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+82749-0100-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+82996-0002-01:	5dtq143 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+51414-0912-13:	5hzv1pn -> 41hv35f	Ethanol 0.62 mL/mL Topical Gel 	0.56 mL
+59898-0420-36:	5hzv1pn -> 41hv35f	Ethanol 0.62 mL/mL Topical Gel 	0.56 mL
+49953-1895-01:	5jqbcva -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+61333-0211-01:	5vezsgx -> tb9rxqx	Benzocaine 100 mg/mL Medicated Pad 	40 mg
+73288-0004-01:	5vezsgx -> tb9rxqx	Benzocaine 100 mg/mL Medicated Pad 	40 mg
+73288-0006-01:	5vezsgx -> tb9rxqx	Benzocaine 100 mg/mL Medicated Pad 	40 mg
+55670-0956-01:	5w5e3mz -> apczffq	Benzocaine 200 mg/mL / menthol 10 mg/mL Medicated Pad [Medicaine Sting] 	120; 6 mg; mg
+37205-0338-16:	5xj79v3 -> aqmamkz	Diphenhydramine HCl 20 mg/mL / zinc acetate 1 mg/mL Topical Spray [Wal-Dryl] 	0; 0 KG; KG
+72476-0295-20:	5xj79v3 -> aqmamkz	Diphenhydramine HCl 20 mg/mL / zinc acetate 1 mg/mL Topical Spray [Wal-Dryl] 	0; 0 KG; KG
+65585-0522-02:	69k1jtp -> n8h88e0	Ethanol 0.6 mL/mL Topical Gel 	142.2 mL
+82996-0005-01:	6aaqe42 -> fn40e37	Ethanol 0.62 mL/mL Topical Solution 	558 mg
+00924-7111-00:	6b4k0jp -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+52410-4107-07:	6b4k0jp -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+00924-5607-01:	6pnb3nr -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00924-5620-00:	6pnb3nr -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+55550-0730-21:	6pnb3nr -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+59898-0730-36:	6pnb3nr -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+70430-0001-01:	6s6vx2k -> v1vgbtx	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	350 mg
+37205-0871-34:	6saa975 -> p0apyv1	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0.01 KG
+49687-0015-01:	6vvdnsg -> s0g9b79	Ethanol 0.62 mL/mL Topical Gel 	558 mg
+00404-0360-47:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+00498-0750-02:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+00498-0750-03:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+00498-0750-34:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+00498-0750-38:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00498-0750-39:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00904-6680-67:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+00904-8805-67:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+00924-5604-01:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00924-5604-02:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00924-5604-03:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00924-5604-04:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00924-5604-05:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+00924-5604-06:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+11527-0162-27:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+45802-0143-70:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+47682-0223-12:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0223-35:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0223-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0227-12:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0227-35:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0227-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0391-35:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0391-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0392-35:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0392-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0393-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0934-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0938-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+47682-0982-35:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+47682-0982-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+47682-0983-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+49687-0013-00:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+50332-0032-01:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+50332-0032-02:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+50332-0032-03:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+50332-0032-04:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+50332-0032-05:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+50332-0032-06:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+51672-2120-06:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+51672-2120-08:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+51672-2120-09:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+53329-0087-96:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+57243-0120-01:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+57896-0143-14:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+59961-0143-45:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+61010-5600-02:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+61010-5600-03:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+61010-5600-04:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+61010-5603-04:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+65923-0391-20:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+65923-0391-21:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+65923-0391-44:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+65923-0391-45:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+69396-0002-09:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+69396-0002-25:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+69396-0062-09:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+69842-0162-10:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+69968-0634-09:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+70082-0603-04:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+71338-0121-73:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+71927-0016-02:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+71927-0016-03:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+71927-0017-02:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+71927-0017-03:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+71927-0017-04:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+72663-0561-12:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+73288-0005-01:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+73408-0929-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+73408-0930-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+73408-0931-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+73408-0932-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+73408-0934-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+73408-0935-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [USP'U]; mg; [USP'U]
+73408-0983-73:	6xg34q2 -> 9jjbtne	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 1.75; 2500 [IU]; mg; [IU]
+81417-0128-01:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+83165-0005-00:	6xg34q2 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 U; mg; U
+25113-0444-16:	7e96ryn -> q4p6kxn	Ethanol 0.665 mL/mL Topical Gel 	39.23 mg
+10819-3916-01:	7fw7jbx -> 1sf16b5	Ethanol 0.7 mL/mL Medicated Pad 	0.5 mL
+67777-0330-01:	7fw7jbx -> 1sf16b5	Ethanol 0.7 mL/mL Medicated Pad 	0.5 mL
+74835-0012-01:	7fw7jbx -> s8wpm79	Ethanol 0.7 mL/mL Medicated Pad 	0.48 mL
+74835-0012-02:	7fw7jbx -> s8wpm79	Ethanol 0.7 mL/mL Medicated Pad 	0.48 mL
+74835-0012-03:	7fw7jbx -> s8wpm79	Ethanol 0.7 mL/mL Medicated Pad 	0.48 mL
+74835-0012-04:	7fw7jbx -> s8wpm79	Ethanol 0.7 mL/mL Medicated Pad 	0.48 mL
+79906-0001-01:	7gfagd2 -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+80514-0001-01:	7gfagd2 -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+50814-0040-01:	7m19asn -> 4tq55tm	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	90; 9 mg; mg
+50814-0065-00:	7m19asn -> zbwmah1	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	135; 13.5 mg; mg
+82996-0003-01:	7m19asn -> 3d1y11n	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	270; 27 mg; mg
+67777-0420-01:	7n4j534 -> 5xd6256	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	30 mg
+79992-0650-14:	7w7kqzw -> 5ywxdm9	Ethanol 0.65 mL/mL Topical Gel 	0.62 L
+00924-8112-00:	8a3qcpa -> tkypk8h	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	5 mg
+41190-0822-43:	8a84rtr -> q36bk6f	Witch hazel 860 mg/mL Topical Solution 	0.41 KG
+41250-0822-43:	8a84rtr -> q36bk6f	Witch hazel 860 mg/mL Topical Solution 	0.41 KG
+55301-0822-43:	8a84rtr -> q36bk6f	Witch hazel 860 mg/mL Topical Solution 	0.41 KG
+55316-0822-43:	8a84rtr -> q36bk6f	Witch hazel 860 mg/mL Topical Solution 	0.41 KG
+51414-0909-01:	8bk9kgt -> f02yhwj	Lidocaine 0.02 mg/mg Topical Gel 	10 mg
+68776-1003-05:	8cq1gbn -> h9cx7a8	Benzalkonium chloride 1 mg/mL Topical Lotion 	205899.6 mg
+70769-0101-51:	8df6nxc -> 89c74va	Benzocaine 200 mg/mL Medicated Pad [Orajel] 	30 mg
+72932-0004-00:	8ffg4tt -> q67pfk0	Benzocaine 60 mg/mL / isopropyl alcohol 0.7 mL/mL Medicated Pad 	24; 0.28 mg; mL
+00924-0450-00:	8fw7ght -> 7f9eqdn	Ethanol 0.665 mL/mL Topical Gel 	22.61 mL
+77209-9664-01:	8qnj2y1 -> a3rnfc9	Ethanol 0.8 mL/mL Topical Gel 	0.76 L
+51811-0400-44:	953mkeb -> we5gjbw	Ethanol 0.7 mL/mL Topical Gel 	165.2 mg
+51811-0400-45:	953mkeb -> we5gjbw	Ethanol 0.7 mL/mL Topical Gel 	165.2 mg
+61010-1112-05:	957dtne -> ytekgnv	Ethanol 0.665 mL/mL Topical Gel 	78.47 mL
+65734-0504-36:	9anck9z -> h8d5498	Benzalkonium chloride 1.1 mg/mL Medicated Pad 	0.17 mg
+81926-0001-36:	9anck9z -> h8d5498	Benzalkonium chloride 1.1 mg/mL Medicated Pad 	0.17 mg
+79992-0700-14:	9ngznk1 -> 5v5rxhg	Ethanol 0.7 mL/mL Topical Gel 	0.67 L
+11993-0000-01:	9p6sx1e -> ewvzy63	Capsaicin 0.0025 mg/mg Medicated Patch 	0.62 mg
+11993-0000-02:	9p6sx1e -> ewvzy63	Capsaicin 0.0025 mg/mg Medicated Patch 	0.62 mg
+82167-0000-09:	9t4pz1h -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+42947-0500-01:	9xgng82 -> 69xpxqd	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	252 mg
+49687-0012-00:	9xgng82 -> n2vq9vn	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	630 mg
+49687-0018-00:	9xgng82 -> n2vq9vn	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	630 mg
+50332-0046-00:	9xgng82 -> g24hbs0	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	245 mg
+50332-0046-05:	9xgng82 -> g24hbs0	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	245 mg
+50332-0046-07:	9xgng82 -> g24hbs0	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	245 mg
+50814-0039-01:	9xgng82 -> px6aksw	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	315 mg
+50814-0039-02:	9xgng82 -> qh465fg	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	175 mg
+59294-0000-00:	9xgng82 -> 6z4xngb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	280 mg
+59294-0001-00:	9xgng82 -> n2vq9vn	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	630 mg
+69139-0201-01:	9xgng82 -> b26bqz3	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	210 mg
+69139-0216-01:	9xgng82 -> b26bqz3	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	210 mg
+69139-0606-01:	9xgng82 -> b26bqz3	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	210 mg
+70006-0500-01:	9xgng82 -> 69xpxqd	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	252 mg
+71310-0005-01:	9xgng82 -> 6z4xngb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	280 mg
+82996-0000-01:	9xgng82 -> px6aksw	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	315 mg
+89156-0000-00:	9xgng82 -> px6aksw	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	315 mg
+55305-0118-12:	a0m698c -> 6wep4be	Benzalkonium chloride 1 mg/mL Medicated Pad 	0.1 mg
+69139-0400-01:	a0m698c -> t5meexa	Benzalkonium chloride 1 mg/mL Medicated Pad 	0.8 mg
+70108-0012-01:	a0m698c -> n6swznf	Benzalkonium chloride 1 mg/mL Medicated Pad 	0 mg
+70108-0013-01:	a0m698c -> n6swznf	Benzalkonium chloride 1 mg/mL Medicated Pad 	0 mg
+70108-0019-01:	a0m698c -> n6swznf	Benzalkonium chloride 1 mg/mL Medicated Pad 	0 mg
+70108-0020-01:	a0m698c -> n6swznf	Benzalkonium chloride 1 mg/mL Medicated Pad 	0 mg
+00924-1133-00:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-5633-00:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+42213-0370-09:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+43473-0049-01:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0207-99:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0398-99:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0611-99:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0697-99:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+51414-0107-01:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+68599-1182-02:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+82942-1003-01:	a0qmer8 -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-5204-02:	a73dms8 -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+00924-5204-03:	a73dms8 -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+00924-5204-04:	a73dms8 -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+00924-5204-05:	a73dms8 -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+50332-0048-01:	a73dms8 -> 4tekpg3	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	21; 210 mg; mg
+50332-0048-07:	a73dms8 -> 4tekpg3	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	21; 210 mg; mg
+59050-0414-20:	a73dms8 -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+69139-0203-01:	a73dms8 -> nq7c2ns	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	18; 180 mg; mg
+00404-0122-02:	a7k7fn6 -> hk84aeq	Ethanol 0.665 mL/mL Medicated Pad 	1.26 mL
+47682-0350-33:	a7k7fn6 -> hk84aeq	Ethanol 0.665 mL/mL Medicated Pad 	1.26 mL
+61010-2017-01:	a7k7fn6 -> hk84aeq	Ethanol 0.665 mL/mL Medicated Pad 	1.26 mL
+50552-0002-01:	a7sv7f2 -> mt1n3es	Benzalkonium chloride 1.55 mg/mL Medicated Pad 	0.78 mg
+68025-0065-07:	a7yy7yr -> 75etgbt	250 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.25 mg
+68025-0065-30:	a7yy7yr -> 75etgbt	250 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.25 mg
+68025-0066-30:	a7yy7yr -> n6r8k5z	500 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.5 mg
+51532-5400-01:	ab7b99e -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+00498-0750-35:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+50814-0007-01:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+52410-3025-03:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+53329-0087-87:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+55681-0216-01:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 U; mg; U
+61010-5600-01:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+69968-0634-01:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [IU]; mg; [IU]
+72976-0009-01:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+72976-0563-02:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+77338-0302-53:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+81417-0003-01:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+82749-0302-53:	asn17q8 -> d3sxs93	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 3.15; 4500 [USP'U]; mg; [USP'U]
+63710-0005-01:	atsa8ey -> 5mfhz3h	Ethanol 0.7 mL/mL Topical Gel 	0.35 L
+77251-0003-03:	atsa8ey -> 5mfhz3h	Ethanol 0.7 mL/mL Topical Gel 	0.35 L
+51811-0400-20:	avygjzz -> b5vqd12	Ethanol 0.7 mL/mL Topical Gel 	20.3 mg
+51811-0400-21:	avygjzz -> b5vqd12	Ethanol 0.7 mL/mL Topical Gel 	20.3 mg
+51811-0400-25:	avygjzz -> b5vqd12	Ethanol 0.7 mL/mL Topical Gel 	20.3 mg
+34645-5501-00:	awtw70q -> xqbecy5	Povidone-iodine 75 mg/mL Medicated Pad [Betadine] 	3.38 mg
+34645-5502-00:	awtw70q -> 34qdz1a	Povidone-iodine 75 mg/mL Medicated Pad [Betadine] 	1.72 mg
+00498-0143-04:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+00536-1103-01:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+34645-3008-03:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+39892-0101-01:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+51142-0444-01:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+65517-0001-01:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+65517-0002-01:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+81085-0002-01:	b5ptq3s -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+50814-0038-01:	bbk1mdf -> 4tq55tm	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	90; 9 mg; mg
+00924-5610-00:	bgx7fs7 -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+00924-5618-00:	bgx7fs7 -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 U; mg; U
+50382-0023-01:	bgx7fs7 -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+55305-0123-03:	bgx7fs7 -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+65585-0372-03:	bmayebs -> qcar4q5	Ethanol 0.6 mL/mL Topical Spray 	70.8 mL
+65585-0372-06:	bmayebs -> a85wk1c	Ethanol 0.6 mL/mL Topical Spray 	480 mL
+65585-0372-08:	bmayebs -> 5t33vkp	Ethanol 0.6 mL/mL Topical Spray 	142.2 mL
+67777-0121-13:	bsbvp4q -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+67777-0121-14:	bsbvp4q -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+78434-0110-16:	btwyd6r -> 8wm6vr3	Ethanol 0.8 mL/mL Topical Solution 	0.38 L
+00498-0801-01:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+00498-0801-02:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+00498-0801-03:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+00498-0801-32:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+00498-0801-33:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+00498-0801-34:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+42961-0220-02:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+42961-0220-03:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+42961-0220-04:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+50332-0042-01:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+50332-0042-02:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+50332-0042-04:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+67777-0003-01:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+71927-0015-02:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+71927-0015-03:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+71927-0018-02:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+71927-0018-03:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+71927-0018-04:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+82940-0220-01:	bxm92e6 -> 7hb41wa	Hydrocortisone acetate 10 mg/mL Topical Cream [Carmol HC] 	9 mg
+50804-0007-01:	c172p1x -> qmn3p6v	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.03 mL
+41250-0822-99:	c66gzyd -> 5eardde	Witch hazel 860 mg/mL Topical Solution 	0.2 KG
+75205-0258-04:	cg40t0p -> g4xpvdh	Ethanol 0.8 mL/mL Topical Solution 	0.1 L
+78434-0110-04:	cg40t0p -> g4xpvdh	Ethanol 0.8 mL/mL Topical Solution 	0.1 L
+50332-0050-00:	cgqffqe -> fxgfr26	Benzocaine 200 mg/mL / menthol 10 mg/mL Medicated Pad [Medicaine Sting] 	120; 6 mg; mg
+50332-0050-04:	cgqffqe -> fxgfr26	Benzocaine 200 mg/mL / menthol 10 mg/mL Medicated Pad [Medicaine Sting] 	120; 6 mg; mg
+61333-0207-01:	ck16ts5 -> z5kgp0s	Benzalkonium chloride 1.33 mg/mL Medicated Pad 	1.06 mg
+61010-3111-01:	ck9nc4n -> jafxf0w	Ethanol 0.665 mL/mL Topical Solution 	1.26 mL
+00259-2102-05:	d0c88ds -> 2kf0zm5	Dimethicone 20 mg/mL Topical Cream [Mederma Stretch Mark Therapy] 	10 mg
+73744-0267-04:	d6kgrke -> yb8emyv	Ethanol 0.7 mL/mL Topical Gel 	0.17 L
+73744-0268-04:	d6kgrke -> yb8emyv	Ethanol 0.7 mL/mL Topical Gel 	0.17 L
+75205-0258-08:	dbdzcrb -> kz684mt	Ethanol 0.8 mL/mL Topical Solution 	0.2 L
+37205-0871-43:	ded6x7s -> p0apyv1	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0.01 KG
+69396-0001-09:	dedt6jp -> 8jv9jay	Clotrimazole 10 mg/mL Topical Cream [Canesten] 	9 mg
+70815-0003-10:	djm7edy -> qj7yttt	Camphor 0.0259 mg/mg / Capsicum extract 0.0329 mg/mg Medicated Patch 	7.77; 9.87 mg; mg
+70815-0003-25:	djm7edy -> 48wf9g2	Camphor 0.0259 mg/mg / Capsicum extract 0.0329 mg/mg Medicated Patch 	15.54; 19.74 mg; mg
+11822-0871-04:	dkejpmc -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+41190-0871-43:	dkejpmc -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+55316-0871-43:	dkejpmc -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+68025-0066-07:	dqbbq2c -> 3v6bc2a	500 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.5 mg
+68025-0083-07:	dqbbq2c -> apvv1yk	750 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.75 mg
+68025-0083-30:	dqbbq2c -> apvv1yk	750 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.75 mg
+10356-0120-30:	e2a2v6h -> apt46ag	Hydrocortisone 0.01 mg/mg Topical Ointment [Aquaphor Itch Relief] 	9 mg
+82167-0000-01:	e319xwp -> ahvk62v	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.08 mL
+50814-0041-01:	ecmd37n -> tx32cmh	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	108; 10.8 mg; mg
+00924-5204-01:	epkatwy -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+59050-0101-01:	epkatwy -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+71734-0340-01:	epkatwy -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+72976-0010-01:	epkatwy -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+73694-0101-01:	epkatwy -> bsz2yap	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 240 mg; mg
+51811-0400-40:	epnb7kn -> nqn5t53	Ethanol 0.7 mL/mL Topical Gel 	82.6 mg
+51811-0400-41:	epnb7kn -> nqn5t53	Ethanol 0.7 mL/mL Topical Gel 	82.6 mg
+67777-0116-10:	et37fjc -> sfjs5df	Bacitracin 450 [USP'U] Packet 	450 [USP'U]
+77093-0300-06:	exf9477 -> fntc6j7	Isopropyl alcohol 0.7 mL/mL Topical Solution 	0.33 L
+83165-0001-00:	ezhrz6q -> 404sm4s	Ethanol 0.7 mL/mL Medicated Pad 	0.43 mL
+52261-0006-03:	f3k38h1 -> 92sza41	Ethanol 0.8 mL/mL Topical Gel 	0.4 L
+73744-0268-06:	f83792m -> d02p056	Ethanol 0.7 mL/mL Topical Gel 	0.04 L
+74446-0330-02:	f83792m -> d02p056	Ethanol 0.7 mL/mL Topical Gel 	0.04 L
+00404-0172-50:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+00404-0400-47:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+00904-6679-67:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+00904-7023-67:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+00904-8804-67:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+50382-0006-11:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+50382-0006-21:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+53329-0089-86:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+57896-0145-14:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+59898-0720-01:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+59898-0720-02:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+59898-0720-03:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+63517-0220-01:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 U
+65923-0390-20:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+65923-0390-44:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+67777-0008-10:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+69396-0008-09:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+69396-0098-09:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+69396-0104-09:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+69396-0104-25:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+69842-0163-10:	fa6k30y -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+00924-5202-01:	fbm08zg -> 10nb93c	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	20.4; 204 mg; mg
+52261-0006-01:	fcpcazj -> yejht18	Ethanol 0.8 mL/mL Topical Gel 	0.24 L
+47593-0624-38:	ftg6cv5 -> 59hg8qk	Ethanol 0.8 mL/mL Topical Solution 	0.4 L
+77251-0001-02:	ftg6cv5 -> 1z4a7dp	Ethanol 0.8 mL/mL Topical Solution 	0 L
+77251-0001-04:	ftg6cv5 -> 59hg8qk	Ethanol 0.8 mL/mL Topical Solution 	0.4 L
+47682-0035-99:	fxa0pvx -> gstksnq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.5 mL
+67777-0121-16:	fxa0pvx -> gstksnq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.5 mL
+82098-0814-10:	fxa0pvx -> gstksnq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.5 mL
+72663-0560-34:	g2zkh5q -> w8th9h1	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	3; 1.75; 0.4 mg; mg; mg
+37205-0871-45:	g3b6tg1 -> 7n6qmpd	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0.03 KG
+42961-0107-02:	g4zgyn2 -> zptamrb	Benzocaine 200 mg/mL / menthol 10 mg/mL Medicated Pad [Medicaine Sting] 	0.1; 0.01 mg; mg
+34645-4008-03:	g87hebc -> 8d5m6ap	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	0.04 mg
+83165-0002-00:	geqdx5j -> 4kw9yp6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.81 mg
+73744-0258-02:	gjh8tnw -> sd1qj4p	Ethanol 0.8 mL/mL Topical Spray 	0.05 L
+69191-0500-06:	gmncnpr -> kzf1f6f	Lidocaine 0.04 mg/mg Topical Gel [Sonacaine] 	24 mg
+77039-0023-01:	gnwssqx -> cn298d3	Ethanol 0.65 mL/mL Medicated Pad 	0.2 mL
+47682-0321-02:	gqsqzsr -> p829nch	Menthol 70 mg/mL Topical Spray 	4.13 mg
+71441-0180-10:	hsvqm3m -> 3f21g4x	Ethanol 0.75 mL/mL Medicated Pad 	0.61 mL
+73943-0951-01:	jat1c2a -> 3hmqah6	Benzalkonium chloride 1 mg/mL Topical Solution [Clean Force] 	0.01 mg
+51672-4174-06:	jcxkw6v -> 2kajdm5	Imiquimod 37.5 mg/mL Topical Cream [Zyclara] 	9.38 mg
+99207-0270-28:	jcxkw6v -> 2kajdm5	Imiquimod 37.5 mg/mL Topical Cream [Zyclara] 	9.38 mg
+78149-0201-02:	jggcqgh -> evqr1yt	Isopropyl alcohol 0.75 mL/mL Medicated Pad 	525 mg
+42851-0085-30:	jhkss0g -> jsrfty3	Salicylic acid 20 mg/mL Medicated Pad [Stri-Dex] 	16 mg
+42851-0085-60:	jhkss0g -> jsrfty3	Salicylic acid 20 mg/mL Medicated Pad [Stri-Dex] 	16 mg
+69771-0011-05:	jwfe407 -> b6kpnhq	Menthol 0.05 mg/mg Medicated Patch [Absorbine] 	0.77 mg
+69771-0012-05:	jwfe407 -> 2ajtwtx	Menthol 0.05 mg/mg Medicated Patch [Absorbine] 	1.54 mg
+37205-0976-43:	jwjn7h0 -> g0y7bxe	Ethanol 0.7 mL/mL Topical Solution 	0 L
+52261-0902-01:	jy11s8v -> az078zm	Isopropyl alcohol 0.7 mL/mL Topical Gel 	0.08 L
+41190-0871-45:	k08t139 -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+55316-0871-45:	k08t139 -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+00168-0432-24:	k1tynhf -> 6sj8wer	Imiquimod 50 mg/mL Topical Cream [Aldara] 	12.5 mg
+45802-0368-53:	k1tynhf -> 6sj8wer	Imiquimod 50 mg/mL Topical Cream [Aldara] 	12.5 mg
+45802-0368-62:	k1tynhf -> 6sj8wer	Imiquimod 50 mg/mL Topical Cream [Aldara] 	12.5 mg
+51672-4145-06:	k1tynhf -> 6sj8wer	Imiquimod 50 mg/mL Topical Cream [Aldara] 	12.5 mg
+68462-0536-70:	k1tynhf -> 6sj8wer	Imiquimod 50 mg/mL Topical Cream [Aldara] 	12.5 mg
+17518-0030-03:	k29aqhc -> a4sv92f	Dimethicone 13 mg/mL Topical Cream 	16.38 mg
+51811-0100-57:	k69r8xc -> anw77z7	Ethanol 0.665 mL/mL Topical Spray 	19.3 mL
+77251-0001-07:	k6a9r4g -> kz684mt	Ethanol 0.8 mL/mL Topical Solution 	0.2 L
+78434-0110-08:	k6a9r4g -> kz684mt	Ethanol 0.8 mL/mL Topical Solution 	0.2 L
+71584-0109-01:	k9q8e88 -> 1ds1b86	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	0.3; 30 mL; mg
+73744-0269-02:	k9tshry -> ms884m2	Isopropyl alcohol 0.7 mL/mL Topical Gel 	0.66 L
+65585-0378-03:	kmj5wev -> 43r1k4t	Ethanol 0.6 mL/mL Topical Gel 	70.8 mL
+99207-0270-01:	kr75fe2 -> 9ygs3mc	Imiquimod 37.5 mg/mL Topical Cream [Zyclara] 	9.38 mg
+13811-0090-32:	kr8w6dd -> 75etgbt	250 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.25 mg
+13811-0091-32:	kr8w6dd -> n6r8k5z	500 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.5 mg
+13811-0092-32:	kr8w6dd -> apvv1yk	750 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.75 mg
+13811-0093-32:	kr8w6dd -> dqbbq2c	1000 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	1 mg
+70700-0143-35:	kr8w6dd -> 75etgbt	250 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.25 mg
+70700-0144-35:	kr8w6dd -> n6r8k5z	500 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.5 mg
+70700-0145-35:	kr8w6dd -> dqbbq2c	1000 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	1 mg
+70700-0194-35:	kr8w6dd -> apvv1yk	750 mg estradiol 0.001 mg/mg Topical Gel [Divigel] 	0.75 mg
+47682-0225-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+47682-0250-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+47682-0255-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+47682-0308-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+47682-0320-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+47682-0330-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+69396-0107-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+73408-0225-02:	krvpyz0 -> kks9b20	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	1182 mg
+61010-1112-02:	ksw7esg -> 7f9eqdn	Ethanol 0.665 mL/mL Topical Gel 	22.61 mL
+61010-1112-03:	ksw7esg -> 7f9eqdn	Ethanol 0.665 mL/mL Topical Gel 	22.61 mL
+61010-1112-08:	ksw7esg -> 7f9eqdn	Ethanol 0.665 mL/mL Topical Gel 	22.61 mL
+61010-8700-01:	ksw7esg -> xeey8q4	Ethanol 0.665 mL/mL Topical Gel 	532 mg
+42961-0222-01:	m058420 -> f6ftv4t	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	280; 3.5; 3500 [IU]; mg; [IU]
+51811-0400-31:	m29r5fe -> f83792m	Ethanol 0.7 mL/mL Topical Gel 	41.3 mg
+83086-0001-01:	m437h5t -> jep69pc	Benzalkonium chloride 2.6 mg/mL Medicated Pad 	0.03 mg
+86818-0004-02:	m4q7cr0 -> khdybek	Benzalkonium chloride 2 mg/mL Medicated Pad 	1.48 mg
+86818-0004-04:	m4q7cr0 -> khdybek	Benzalkonium chloride 2 mg/mL Medicated Pad 	1.48 mg
+86818-0004-06:	m4q7cr0 -> khdybek	Benzalkonium chloride 2 mg/mL Medicated Pad 	1.48 mg
+11822-0871-07:	m7rnkey -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+61010-3111-02:	mj1cswy -> 67t75qt	Ethanol 0.665 mL/mL Topical Solution 	148.96 mL
+11084-0703-02:	mq6t44c -> 8mymad9	Ethanol 0.7 mL/mL Topical Foam 	0.03 L
+64709-0105-10:	mtgagrb -> 6b4k0jp	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	17 mg
+78847-0320-40:	mtsj4e6 -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+17518-0030-01:	mzetjkz -> 87f9zwt	Dimethicone 13 mg/mL Topical Cream 	0.35 mg
+30805-0001-01:	n60jfwm -> pwkjpg4	Ethanol 0.62 mL/mL Topical Solution 	0.56 mL
+82098-0617-10:	nj6af1f -> v2gjvw8	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	60 mg
+71338-0122-02:	nkkqh90 -> mjeek6y	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.7 mg
+00404-9406-02:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+00404-9407-02:	nm1at8b -> 7chqtj6	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.48 mL
+00404-9408-02:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+00498-0142-34:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+00498-0143-05:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+00498-0143-10:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+00498-0143-33:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+00498-0143-34:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+10819-3914-01:	nm1at8b -> bkwr979	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.43 mL
+11822-5156-02:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+11822-5156-06:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+30142-0809-30:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+34645-0001-01:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+34645-0005-01:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+34645-0008-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+34645-3018-03:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+34645-3110-03:	nm1at8b -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+34645-3111-03:	nm1at8b -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+39892-0100-01:	nm1at8b -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+39892-0100-02:	nm1at8b -> r7vxk7t	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.64 mL
+39892-0100-03:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+41520-0809-30:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+47682-0035-50:	nm1at8b -> gstksnq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.5 mL
+47682-0331-33:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+47682-0331-50:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+50232-0001-01:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+50232-0001-02:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+50232-0001-03:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+50814-0055-01:	nm1at8b -> zftxzjs	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.2 mL
+55550-0040-60:	nm1at8b -> pvh0ajf	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.32 mL
+55550-0801-01:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+59050-0444-20:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+59050-0444-21:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+59050-0448-20:	nm1at8b -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+68196-0500-86:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+68356-0103-03:	nm1at8b -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+68356-0117-02:	nm1at8b -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+69139-0001-01:	nm1at8b -> zmzfc1d	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.15 mL
+69139-0001-02:	nm1at8b -> zmzfc1d	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.15 mL
+71677-5036-03:	nm1at8b -> gstksnq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.5 mL
+71749-0300-10:	nm1at8b -> pw21y07	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.13 mL
+71749-0300-11:	nm1at8b -> pw21y07	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.13 mL
+71749-0300-12:	nm1at8b -> pw21y07	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.13 mL
+71749-0300-13:	nm1at8b -> pw21y07	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.13 mL
+71749-0300-14:	nm1at8b -> pw21y07	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.13 mL
+71884-0013-01:	nm1at8b -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+72459-0010-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+72727-0001-02:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+72932-0001-00:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+73408-0033-50:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+74103-0001-01:	nm1at8b -> pvh0ajf	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.32 mL
+76123-0121-01:	nm1at8b -> 115cayb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.52 mL
+76162-0809-30:	nm1at8b -> g6ytc59	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.35 mL
+77133-0000-00:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+77133-0000-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+77133-0000-02:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+77133-0000-03:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+79611-0111-11:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+79611-0111-12:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+79611-0111-13:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+80244-0002-01:	nm1at8b -> da4j8mz	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.21 mL
+80244-0002-03:	nm1at8b -> da4j8mz	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.21 mL
+81085-0001-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+81085-0001-02:	nm1at8b -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+81316-0001-01:	nm1at8b -> da4j8mz	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.21 mL
+81316-0001-02:	nm1at8b -> da4j8mz	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.21 mL
+81636-0001-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+81636-0005-01:	nm1at8b -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+81849-0001-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+82167-0000-02:	nm1at8b -> ahvk62v	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.08 mL
+82167-0000-03:	nm1at8b -> ahvk62v	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.08 mL
+82167-0000-04:	nm1at8b -> ahvk62v	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.08 mL
+82167-0000-06:	nm1at8b -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+82167-0000-07:	nm1at8b -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+82167-0000-08:	nm1at8b -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+82167-0000-10:	nm1at8b -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+82167-0000-11:	nm1at8b -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+82167-0000-12:	nm1at8b -> dw7zq9k	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.4 mL
+82826-0001-01:	nm1at8b -> s59tf47	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.24 mL
+83446-0001-01:	nm1at8b -> c172p1x	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.28 mL
+83446-0002-01:	nm1at8b -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+73744-0268-07:	nqn5t53 -> 4d0120b	Ethanol 0.7 mL/mL Topical Gel 	0.08 L
+74446-0330-04:	nqn5t53 -> 4d0120b	Ethanol 0.7 mL/mL Topical Gel 	0.08 L
+47682-0257-02:	nqyxgv2 -> 3zacvjg	Hydrogen peroxide 30 mg/mL Topical Spray 	2557.55 mg
+80514-0002-01:	nsxmggp -> 8a3qcpa	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	50 mg
+34645-4190-01:	ntftx2v -> yhrjyn1	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	33.6; 336 mg; mg
+82167-0000-05:	p17hgv7 -> vw169jb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.17 mL
+00924-5201-01:	p3pxzj1 -> jh46jd3	Benzocaine 60 mg/mL Medicated Pad [StingX] 	25.2 mg
+72663-0112-12:	p8pn36r -> 40qtkkj	Ethanol 0.665 mL/mL Topical Gel 	0.6 mL
+69842-0161-10:	p99ftze -> fh9tmjp	Bacitracin 0.5 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 10 UNT/mg / pramoxine HCl 0.01 mg/mg Topical Ointment [Atopalm First Aid Moisturizing and Pain Relief] 	450; 3.15; 9000; 9 [USP'U]; mg; [USP'U]; mg
+70031-0001-01:	pevmnx -> vk89khw	Benzethonium chloride 3 mg/mL Medicated Pad 	0.03 mg
+70031-0001-02:	pevmnx -> vk89khw	Benzethonium chloride 3 mg/mL Medicated Pad 	0.03 mg
+70031-0001-03:	pevmnx -> vk89khw	Benzethonium chloride 3 mg/mL Medicated Pad 	0.03 mg
+70031-0001-04:	pevmnx -> vk89khw	Benzethonium chloride 3 mg/mL Medicated Pad 	0.03 mg
+70031-0001-06:	pevmnx -> vk89khw	Benzethonium chloride 3 mg/mL Medicated Pad 	0.03 mg
+73744-0269-03:	pp36m9s -> grbq8df	Isopropyl alcohol 0.7 mL/mL Topical Gel 	0.33 L
+72189-0084-24:	pxrngnx -> 6sj8wer	Imiquimod 50 mg/mL Topical Cream [Aldara] 	12.5 mg
+83006-0002-00:	q0xxb1g -> 1xjwmax	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	1.04 mg
+65585-0375-01:	q1h9b5b -> 3tspfv9	Ethanol 0.6 mL/mL Topical Gel 	480 mL
+65585-0375-02:	q1h9b5b -> 43r1k4t	Ethanol 0.6 mL/mL Topical Gel 	70.8 mL
+65585-0375-06:	q1h9b5b -> n8h88e0	Ethanol 0.6 mL/mL Topical Gel 	142.2 mL
+65585-0375-10:	q1h9b5b -> 3tspfv9	Ethanol 0.6 mL/mL Topical Gel 	480 mL
+65585-0375-17:	q1h9b5b -> 3tspfv9	Ethanol 0.6 mL/mL Topical Gel 	480 mL
+65585-0376-03:	q1h9b5b -> 3tspfv9	Ethanol 0.6 mL/mL Topical Gel 	480 mL
+65585-0376-06:	q1h9b5b -> 6v92axe	Ethanol 0.6 mL/mL Topical Gel 	70.98 mL
+65585-0378-01:	q1h9b5b -> 3tspfv9	Ethanol 0.6 mL/mL Topical Gel 	480 mL
+65585-0378-04:	q1h9b5b -> 43r1k4t	Ethanol 0.6 mL/mL Topical Gel 	70.8 mL
+65585-0378-05:	q1h9b5b -> n8h88e0	Ethanol 0.6 mL/mL Topical Gel 	142.2 mL
+65585-0525-01:	q1h9b5b -> 3tspfv9	Ethanol 0.6 mL/mL Topical Gel 	480 mL
+10356-0101-44:	q53hr8e -> 2y5etdt	Petrolatum 0.41 mg/mg Topical Ointment [Aquaphor] 	370 mg
+51142-0445-21:	q6z7zcc -> wf2dnzg	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	238 mg
+50241-0326-00:	qbmsc1c -> g2rrzrk	Ethanol 0.62 mL/mL Topical Gel 	0.3 L
+50814-0058-01:	qnm5z2t -> s72618w	Bacitracin 400 UNT/mL / neomycin 3.5 mg/mL / polymyxin B 5000 UNT/mL Topical Cream 	360; 3.15; 4500 [IU]; mg; [IU]
+73744-0269-04:	qr5n6kh -> ebn7atc	Isopropyl alcohol 0.7 mL/mL Topical Gel 	0.17 L
+10356-0101-30:	r126sbf -> 2y5etdt	Petrolatum 0.41 mg/mg Topical Ointment [Aquaphor] 	370 mg
+27854-0311-01:	r4pgkkx -> 5pr570b	Lidocaine 0.04 mg/mg Medicated Patch [Lidocare] 	9.6 mg
+41167-0584-00:	r4pgkkx -> xvj5znm	Lidocaine 0.04 mg/mg Medicated Patch [Lidocare] 	9.84 mg
+49873-0617-01:	r4pgkkx -> z0w2y61	Lidocaine 0.04 mg/mg Medicated Patch [Lidocare] 	16 mg
+55319-0959-01:	r4pgkkx -> 87944s0	Lidocaine 0.04 mg/mg Medicated Patch [Lidocare] 	1.6 mg
+69771-0010-05:	r4pgkkx -> cg9x6ae	Lidocaine 0.04 mg/mg Medicated Patch [Lidocare] 	0.97 mg
+71399-4456-05:	r4pgkkx -> xvj5znm	Lidocaine 0.04 mg/mg Medicated Patch [Lidocare] 	9.84 mg
+47682-0243-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+47682-0245-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+47682-0254-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+47682-0316-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+47682-0317-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+47682-0333-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+73408-0245-02:	r4s3a6v -> x3hcgry	Benzalkonium chloride 1.3 mg/mL Topical Spray [Zephiran] 	76.83 mg
+81280-0002-01:	r6ew8cb -> 4r0ga1p	Povidone-iodine 10 mg/mL Medicated Pad 	0.03 mg
+82317-0001-01:	rcvprvg -> r5cj7z5	Lidocaine HCl 0.005 mg/mg Topical Gel [Solarcaine] 	2.5 mg
+51824-0050-14:	rcvwkhf -> 7abgq5e	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	900 mg
+59088-0396-54:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+59088-0396-82:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+63629-7059-01:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+63629-7059-02:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+63629-7059-03:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+63629-7059-04:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+63629-7059-05:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+63629-7059-06:	rn72wk2 -> 3646vyp	Lidocaine 0.05 mg/mg Medicated Patch [Lidoderm] 	35 mg
+58980-0012-01:	rtjf8sx -> zq8c4xw	Bacitracin 0.5 UNT/mg / polymyxin B 10 UNT/mg Topical Ointment [Betadine Antibiotic] 	450; 9000 [USP'U]; [USP'U]
+69968-0060-09:	rtjf8sx -> czjr27x	Bacitracin 0.5 UNT/mg / polymyxin B 10 UNT/mg Topical Ointment [Polysporin] 	450; 9000 [USP'U]; [USP'U]
+83165-0003-00:	rvzw5ay -> 3290vkt	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	372; 37.2 mg; mg
+17518-0030-02:	rw0a3p7 -> q48ar6q	Dimethicone 13 mg/mL Topical Cream 	4.98 mg
+00498-0730-05:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00924-5607-02:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00924-5607-03:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00924-5607-05:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00924-5620-01:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00924-5620-02:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+59898-0730-01:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+59898-0730-02:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+59898-0730-03:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+61010-6700-02:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+61010-6700-03:	rwfzaep -> f1e94jg	Neomycin 0.0035 mg/mg Topical Ointment 	3.15 mg
+00404-0167-50:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+00924-5610-01:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+00924-5610-02:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+00924-5618-04:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 U; mg; U
+39892-0830-01:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+42961-0222-02:	ry950ys -> f6ftv4t	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	280; 3.5; 3500 [IU]; mg; [IU]
+42961-0222-03:	ry950ys -> f6ftv4t	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	280; 3.5; 3500 [IU]; mg; [IU]
+42961-0222-04:	ry950ys -> f6ftv4t	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	280; 3.5; 3500 [IU]; mg; [IU]
+50382-0023-04:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+50382-0023-05:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+50382-0023-11:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+50382-0023-21:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+51824-0052-14:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [USP'U]; mg; [USP'U]
+51824-0052-25:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [USP'U]; mg; [USP'U]
+55305-0123-02:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+58228-2009-02:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+67060-0360-39:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+67777-0217-15:	ry950ys -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+67777-0217-17:	ry950ys -> fcc2cks	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	200; 2.5; 2500 [IU]; mg; [IU]
+72976-0007-01:	rybg1qf -> 9842sfk	Ethanol 0.72 mL/mL Topical Gel 	648 mg
+83006-0004-00:	s7bp21x -> 4akafwp	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	48; 0.48 mg; mL
+63710-0005-04:	scebkps -> d02p056	Ethanol 0.7 mL/mL Topical Gel 	0.04 L
+00924-5203-02:	smbpjjp -> e0skpjg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 0.24 mg; mL
+00924-5203-03:	smbpjjp -> e0skpjg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 0.24 mg; mL
+00924-5203-04:	smbpjjp -> e0skpjg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 0.24 mg; mL
+47682-0234-12:	smbpjjp -> atz4xwg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	36; 0.36 mg; mL
+72459-0013-01:	smbpjjp -> e0skpjg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 0.24 mg; mL
+61010-3111-03:	sn66rf2 -> jw0fdeb	Ethanol 0.665 mL/mL Topical Solution 	385.7 mL
+47682-0234-99:	srmnmt5 -> atz4xwg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	36; 0.36 mg; mL
+65585-0375-15:	st81qgj -> d3y37yh	Ethanol 0.6 mL/mL Topical Gel 	283.8 mL
+80514-0005-01:	sw8ry60 -> mzkyj45	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	30; 300 mg; mg
+65585-0376-01:	sz7s8hb -> 8zw5xa6	Ethanol 0.6 mL/mL Topical Gel 	141.96 mL
+49035-0890-01:	t6e3mm3 -> 2cn28cq	Capsaicin 0.00025 mg/mg Medicated Patch [WellPatch] 	0 mg
+49035-0890-04:	t6e3mm3 -> 2cn28cq	Capsaicin 0.00025 mg/mg Medicated Patch [WellPatch] 	0 mg
+61010-1112-06:	tedfhv8 -> yy3qdaa	Ethanol 0.665 mL/mL Topical Gel 	157.6 mL
+73375-7800-06:	tedfhv8 -> yy3qdaa	Ethanol 0.665 mL/mL Topical Gel 	157.6 mL
+73744-0267-03:	tepm2hx -> ka2jv0m	Ethanol 0.7 mL/mL Topical Gel 	0.33 L
+73744-0268-03:	tepm2hx -> ka2jv0m	Ethanol 0.7 mL/mL Topical Gel 	0.33 L
+74446-0330-16:	tepm2hx -> ka2jv0m	Ethanol 0.7 mL/mL Topical Gel 	0.33 L
+52261-0901-01:	tesknrd -> 4d0120b	Ethanol 0.7 mL/mL Topical Gel 	0.08 L
+50814-0041-02:	tgbbpny -> d5174rf	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	318; 31.8 mg; mg
+51414-0107-02:	tj5zyev -> 632cy3c	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	5 mg
+68599-1183-01:	tj8rnfv -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [USP'U]; mg; [USP'U]
+70897-0003-01:	tj8rnfv -> r55d93b	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	360; 4.5; 4500 [IU]; mg; [IU]
+67777-0418-01:	tn7xghz -> 5x7athz	Povidone-iodine 0.1 mg/mg Topical Gel [Biozide] 	3 mg
+00924-5203-01:	tndpcqr -> e0skpjg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 0.24 mg; mL
+65517-0005-01:	tndpcqr -> e0skpjg	Benzocaine 60 mg/mL / isopropyl alcohol 0.6 mL/mL Medicated Pad 	24; 0.24 mg; mL
+80384-0001-03:	tx0c2ep -> p320x9p	Ethanol 0.6 mL/mL Topical Gel 	180 mg
+00924-8110-00:	ty189nx -> rbz67yb	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	45 mg
+34645-0022-00:	ty189nx -> wfjqwdj	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	40 mg
+34645-5500-01:	ty189nx -> k73v6qc	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	4.3 mg
+34645-5503-00:	ty189nx -> kkksbyn	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	2.3 mg
+34645-5504-00:	ty189nx -> 1b02v1v	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	4.5 mg
+50332-0047-00:	ty189nx -> jcjecmc	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	35 mg
+50332-0047-07:	ty189nx -> jcjecmc	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	35 mg
+50685-0009-01:	ty189nx -> z82bqgn	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	70 mg
+63517-0400-83:	ty189nx -> v3f5w9k	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	56 mg
+67777-0002-01:	ty189nx -> 5xd6256	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	30 mg
+72459-0012-01:	ty189nx -> b5crryj	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	55 mg
+72932-0003-00:	ty189nx -> rbz67yb	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	45 mg
+47593-0624-23:	tyqpvt5 -> k58wsx1	Ethanol 0.8 mL/mL Topical Solution 	0.76 L
+78434-0110-32:	tyqpvt5 -> k58wsx1	Ethanol 0.8 mL/mL Topical Solution 	0.76 L
+69396-0108-02:	vcj68hs -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+23957-0001-72:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+39892-0304-01:	vhk810k -> pma6yws	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.98 mg
+39892-0305-01:	vhk810k -> pma6yws	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.98 mg
+39892-0306-01:	vhk810k -> pma6yws	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.98 mg
+42326-0098-01:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+42326-0100-01:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+42326-0100-60:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+49687-0011-01:	vhk810k -> 2fnpynn	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	1.17 mg
+50814-0002-01:	vhk810k -> 80aw4nn	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.6 mg
+50814-0002-02:	vhk810k -> 3m67atf	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.33 mg
+50814-0057-01:	vhk810k -> nxjwz9w	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.3 mg
+51706-0928-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+51706-0955-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+51706-0958-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+59050-0262-01:	vhk810k -> e06344d	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.44 mg
+59050-0264-01:	vhk810k -> e06344d	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.44 mg
+59050-0434-20:	vhk810k -> e4tn5gz	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.52 mg
+66902-0386-80:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+67777-0243-03:	vhk810k -> m9c6q9x	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.72 mg
+67777-0244-01:	vhk810k -> m9c6q9x	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.72 mg
+67777-0245-02:	vhk810k -> m9c6q9x	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.72 mg
+67777-0245-04:	vhk810k -> m9c6q9x	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.72 mg
+67777-0245-05:	vhk810k -> m9c6q9x	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.72 mg
+67777-0245-11:	vhk810k -> m9c6q9x	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.72 mg
+69540-0036-01:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+69540-0036-02:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+69540-0036-03:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+69540-0036-04:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+69821-0001-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-02:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-03:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-04:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-05:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-06:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-07:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-08:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-09:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-10:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-11:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-12:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-13:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-14:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-15:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-16:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-17:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+69821-0001-18:	vhk810k -> 2bd5ebt	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.47 mg
+69821-0001-20:	vhk810k -> 2fnpynn	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	1.17 mg
+69821-0004-01:	vhk810k -> e4tn5gz	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.52 mg
+69821-0005-01:	vhk810k -> e4tn5gz	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.52 mg
+70697-0806-01:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+70972-1200-01:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+73015-0001-01:	vhk810k -> 1rbqvz4	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.08 mg
+73015-0001-02:	vhk810k -> n9p3ay4	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.05 mg
+73015-0001-03:	vhk810k -> n9p3ay4	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.05 mg
+73015-0001-04:	vhk810k -> dk6aaxa	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.16 mg
+73015-0001-05:	vhk810k -> b436bz6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.27 mg
+73015-0001-06:	vhk810k -> e06344d	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.44 mg
+73015-0001-07:	vhk810k -> xsrgqkc	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.55 mg
+73015-0001-08:	vhk810k -> b436bz6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.27 mg
+73015-0001-09:	vhk810k -> e06344d	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.44 mg
+73015-0001-10:	vhk810k -> xsrgqkc	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.55 mg
+73760-0001-01:	vhk810k -> s6nnfe7	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.1 mg
+73760-0001-02:	vhk810k -> er730j6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.2 mg
+73760-0001-04:	vhk810k -> mc3xcy6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.07 mg
+73760-0001-05:	vhk810k -> e4tn5gz	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.52 mg
+73760-0001-06:	vhk810k -> 3m67atf	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.33 mg
+73760-0001-07:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+73760-0001-08:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+73760-0001-09:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+73760-0002-01:	vhk810k -> x6677me	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.75 mg
+73760-0004-01:	vhk810k -> 4rxxq5d	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.45 mg
+73760-0005-01:	vhk810k -> 7xaqkct	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.43 mg
+73760-0006-01:	vhk810k -> wbf4pfs	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.5 mg
+73760-0007-01:	vhk810k -> 7xaqkct	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.43 mg
+73760-0008-01:	vhk810k -> mc3xcy6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.07 mg
+73760-0008-02:	vhk810k -> wve7hmf	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.11 mg
+73760-0008-03:	vhk810k -> qrn0qmv	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.35 mg
+74602-0700-10:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+74602-0700-80:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+74835-0013-01:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-02:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-03:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-04:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-05:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-06:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-07:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74835-0013-08:	vhk810k -> b9kxayg	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0 mg
+74934-0089-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-02:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-03:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-04:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-05:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-06:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-07:	vhk810k -> qrn0qmv	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.35 mg
+75213-0002-08:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-09:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75213-0002-10:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+75670-0004-01:	vhk810k -> epa4xw8	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.4 mg
+77435-0220-01:	vhk810k -> cqzxksv	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.63 mg
+77435-0221-01:	vhk810k -> cqzxksv	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.63 mg
+77677-0013-01:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+77677-0013-20:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+78940-0001-02:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+78940-0001-03:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+78940-0001-04:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+78940-0001-05:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+78940-0001-06:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+81072-0001-01:	vhk810k -> b436bz6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.27 mg
+81072-0001-02:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+81072-0001-03:	vhk810k -> 3m67atf	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.33 mg
+81072-0001-04:	vhk810k -> gda7w2w	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.13 mg
+81072-0001-11:	vhk810k -> b436bz6	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.27 mg
+81072-0001-12:	vhk810k -> w8g3rdw	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.17 mg
+81072-0001-13:	vhk810k -> 3m67atf	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.33 mg
+81072-0001-14:	vhk810k -> gda7w2w	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.13 mg
+81331-0001-13:	vhk810k -> e4tn5gz	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.52 mg
+81991-0002-37:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+83061-0001-01:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+83061-0001-02:	vhk810k -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+50685-0006-01:	vhkkjjb -> fm4dmyt	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	294 mg
+52261-0006-02:	vjcn32t -> 5c96nsk	Ethanol 0.8 mL/mL Topical Gel 	0.38 L
+11822-0871-05:	vn4fn1v -> 1dwyjfn	Hydrogen peroxide 30 mg/mL Topical Solution [Proxacol] 	0 KG
+71338-0138-02:	vvj5c88 -> a3vd0p	Lidocaine HCl 20 mg/mL Topical Spray [Pro Pet Skin Relief] 	11.8 mg
+61010-8300-01:	vyqzc1r -> 48xfbq2	Diphenhydramine HCl 20 mg/mL Topical Solution 	1199.73 mg
+39892-0810-01:	wae18pw -> et37fjc	Bacitracin 0.5 UNT/mg Topical Ointment [Baciguent] 	450 [IU]
+71310-0202-00:	wavawwm -> 6z4xngb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	280 mg
+71734-0341-01:	wavawwm -> 6z4xngb	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	280 mg
+50814-0041-03:	wcve21v -> zbwmah1	Benzocaine 60 mg/mL / ethanol 0.6 mL/mL Medicated Pad 	135; 13.5 mg; mg
+74446-0330-08:	we5gjbw -> yb8emyv	Ethanol 0.7 mL/mL Topical Gel 	0.17 L
+77251-0003-02:	we5gjbw -> yb8emyv	Ethanol 0.7 mL/mL Topical Gel 	0.17 L
+50685-0007-01:	wfjqwdj -> x0tsd7a	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	4 mg
+50382-0020-11:	wncqwdc -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+61010-5000-04:	wncqwdc -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+61010-5000-05:	wncqwdc -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+61010-5000-06:	wncqwdc -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+69396-0106-09:	wncqwdc -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+43473-0048-01:	wpbhn0z -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+61010-5000-03:	wpbhn0z -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+82942-1001-01:	wpbhn0z -> wedm76p	Lidocaine HCl 0.02 mg/mg Topical Gel [Xylocaine] 	18 mg
+47682-0350-99:	ww4zdcb -> hk84aeq	Ethanol 0.665 mL/mL Medicated Pad 	1.26 mL
+61010-2017-00:	ww4zdcb -> hk84aeq	Ethanol 0.665 mL/mL Medicated Pad 	1.26 mL
+61333-0203-01:	wwva851 -> db56bts	Povidone-iodine 100 mg/mL Medicated Pad [Betadine] 	6.7 mg
+68599-1120-01:	wz839yb -> g7kqt4d	Ethanol 0.665 mL/mL Topical Gel 	598.5 mg
+59898-0420-04:	x3a196h -> 41hv35f	Ethanol 0.62 mL/mL Topical Gel 	0.56 mL
+73408-0512-73:	x3a196h -> 41hv35f	Ethanol 0.62 mL/mL Topical Gel 	0.56 mL
+69540-0037-01:	x81ad9x -> b2w2y39	Ethanol 0.71 mL/mL Medicated Pad 	0.5 mL
+69540-0037-02:	x81ad9x -> b2w2y39	Ethanol 0.71 mL/mL Medicated Pad 	0.5 mL
+69540-0037-03:	x81ad9x -> b2w2y39	Ethanol 0.71 mL/mL Medicated Pad 	0.5 mL
+69540-0037-04:	x81ad9x -> b2w2y39	Ethanol 0.71 mL/mL Medicated Pad 	0.5 mL
+69540-0037-05:	x81ad9x -> b2w2y39	Ethanol 0.71 mL/mL Medicated Pad 	0.5 mL
+00924-1133-01:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-1133-02:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-1133-03:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-1133-04:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-1133-05:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-1133-06:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-5633-01:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+00924-5633-02:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0207-12:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0207-35:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0207-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0211-12:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0211-35:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0211-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0397-35:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0397-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0398-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0611-12:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0611-35:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0611-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0633-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0697-35:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0697-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0923-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0933-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0980-35:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0980-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+47682-0981-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+50382-0024-11:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+58228-2045-02:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+61010-5800-02:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+61010-5800-03:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+61010-5800-04:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+65923-0393-20:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+65923-0393-44:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+67060-0370-39:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+67777-0004-04:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+69103-4506-03:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+73408-0633-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+73408-0933-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+73408-0981-73:	x8pfscf -> 7cf8z8r	Hydrocortisone 10 mg/mL Topical Cream [Hydrocortistab] 	9 mg
+11084-0703-40:	xgy9gvg -> ktt2fh8	Ethanol 0.7 mL/mL Topical Foam 	0.28 L
+00498-0903-34:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+00924-5011-01:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+00924-5011-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+00924-5011-03:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+00924-5011-04:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+42961-0214-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0260-12:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0260-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0270-12:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0270-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0319-35:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0319-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0326-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0930-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0940-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0984-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+47682-0985-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+49314-0003-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+49687-0014-00:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+49687-0017-00:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50332-0037-01:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50332-0037-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50332-0037-04:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50332-0037-06:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50382-0022-11:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50382-0022-12:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50382-0022-13:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+50382-0022-14:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+58228-2044-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+59898-0902-01:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+59898-0902-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+59898-0902-03:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+61010-5701-04:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+61010-5701-05:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+61010-5701-06:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+69396-0105-09:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+71338-0123-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+71927-0019-02:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+71927-0019-03:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+73408-0260-12:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+73408-0260-73:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+82940-0214-01:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+83165-0004-00:	xkg3at1 -> xcj5edh	Benzalkonium chloride 1.3 mg/mL / lidocaine HCl 5 mg/mL Topical Cream [Healerz for Noses] 	1.17; 4.5 mg; mg
+72663-0111-23:	xrwxv67 -> ag6p39n	Ethanol 0.665 mL/mL Topical Gel 	599.4 mg
+50332-0030-04:	xsf07sv -> fa6k30y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	500 U
+67777-0014-65:	y4d3qms -> 41zsgkr	Petrolatum 1 mg/mg Topical Ointment [Ilex Skin] 	370 mg
+45802-0962-72:	yanq3yx -> cnsaj75	Erythromycin 20 mg/mL Topical Solution [A/T/S] 	16 mg
+63629-8648-01:	yanq3yx -> cnsaj75	Erythromycin 20 mg/mL Topical Solution [A/T/S] 	16 mg
+77338-0303-52:	yhk1856 -> et37fjc	Bacitracin 0.5 UNT/mg Topical Ointment [Baciguent] 	450 [USP'U]
+82539-0211-02:	yjq7dx2 -> cyr0m6f	Ethanol 0.62 mL/mL Medicated Pad 	0.37 mL
+82539-0211-10:	yjq7dx2 -> cyr0m6f	Ethanol 0.62 mL/mL Medicated Pad 	0.37 mL
+82539-0211-11:	yjq7dx2 -> cyr0m6f	Ethanol 0.62 mL/mL Medicated Pad 	0.37 mL
+82539-0211-12:	yjq7dx2 -> cyr0m6f	Ethanol 0.62 mL/mL Medicated Pad 	0.37 mL
+52410-3035-02:	ymtz51r -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+53329-0089-87:	ymtz51r -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [USP'U]
+55681-0218-01:	ymtz51r -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 U
+59898-0720-36:	ymtz51r -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+68599-1184-01:	ymtz51r -> mt46s5y	Bacitracin zinc 0.5 UNT/mg Topical Ointment 	450 [IU]
+00498-0733-10:	ypgvcyr -> sh83dmk	Ethanol 0.5 mL/mL / lidocaine HCl 20 mg/mL Medicated Pad 	0.2; 8 mL; mg
+00498-0733-34:	ypgvcyr -> sh83dmk	Ethanol 0.5 mL/mL / lidocaine HCl 20 mg/mL Medicated Pad 	0.2; 8 mL; mg
+00498-1733-34:	ypgvcyr -> sh83dmk	Ethanol 0.5 mL/mL / lidocaine HCl 20 mg/mL Medicated Pad 	0.2; 8 mL; mg
+83006-0003-00:	yrvm54h -> 3zw03yq	Isopropyl alcohol 0.7 mL/mL Medicated Pad 	0.56 mL
+51532-5500-01:	yxwx68b -> mhrqryq	Isopropyl alcohol 0.7 mL/mL Topical Spray 	41.3 mL
+73598-1004-01:	yz4g7kb -> 6xg34q2	Bacitracin 0.4 UNT/mg / neomycin 0.0035 mg/mg / polymyxin B 5 UNT/mg Topical Ointment [Mycitracin Triple Antibiotic] 	400; 3.5; 5000 [IU]; mg; [IU]
+72749-0008-03:	z2bp7sn -> g55yjvx	Menthol 0.07 mg/mg Medicated Patch 	12.6 mg
+77251-0001-05:	z3c5t5a -> kz684mt	Ethanol 0.8 mL/mL Topical Solution 	0.2 L
+78940-0001-01:	z4wk4dn -> 8xyrvzb	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.01 mg
+47682-0304-02:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+47682-0324-02:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+47682-0334-02:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+69103-5400-00:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+71338-0141-02:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+78495-0152-01:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+78495-0162-01:	z8q07ne -> fr33cj3	Hydrogen peroxide 30 mg/mL Topical Spray 	1.77 mL
+50814-0008-01:	zc6xekp -> w6bedpk	Ethanol 0.62 mL/mL Topical Gel 	0.5 mL
+49953-0925-01:	zf7hjz6 -> r7nkcee	Glycerin 75 mg/mL Medicated Pad 	47.25 mg
+67777-0161-10:	zf7hjz6 -> pm1fq9f	Glycerin 22.5 mg Applicator [Lemon Glycerin] 	22.5 mg
+69821-0003-07:	zfjtzzv -> nkr59ha	Ethanol 0.7 mL/mL Medicated Pad 	336 mg
+69821-0003-08:	zfjtzzv -> zkp0qx5	Ethanol 0.7 mL/mL Medicated Pad 	330 mg
+69821-0003-09:	zfjtzzv -> nkr59ha	Ethanol 0.7 mL/mL Medicated Pad 	336 mg
+69821-0003-10:	zfjtzzv -> nkr59ha	Ethanol 0.7 mL/mL Medicated Pad 	336 mg
+69821-0003-11:	zfjtzzv -> nkr59ha	Ethanol 0.7 mL/mL Medicated Pad 	336 mg
+44577-0040-20:	zkgjek1 -> myz0ahx	Salicylic acid 0.4 mg/mg Medicated Patch [Verrustat] 	2 mg
+51414-0909-02:	zpkkcwr -> q96w8px	Lidocaine 0.02 mg/mg Topical Gel 	18 mg
+16110-0391-05:	zwsa3at -> sp5ax5t	Tirbanibulin 0.01 mg/mg Topical Ointment [Klisyri] 	2.5 mg
+71584-0111-01:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+71584-0111-02:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+71584-0111-03:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+71584-0111-04:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+71584-0111-05:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+71584-0111-06:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+80514-0003-01:	zxnvb8a -> vaz8wm2	Benzalkonium chloride 1.3 mg/mL Medicated Pad [Sani-Hands Basics] 	0.65 mg
+55681-0224-02:	zybm8b3 -> 4e0gqy3	Hydrocortisone acetate 0.01 mg/mg Topical Ointment 	9 mg
+61010-1112-00:	zz31pev -> yt1xm1s	Ethanol 0.665 mL/mL Topical Gel 	30.6 mL
+
+
+6/13/2024:
 69423-0382-10:	rnwdxx1 -> n36amry	Aluminum chlorohydrate 25145 mg Can [Secret Dry Light Essentials]
 69423-0384-10:	rnwdxx1 -> n36amry	Aluminum chlorohydrate 25145 mg Can [Secret Outlast Completely Clean Dry]
 69423-0478-10:	rnwdxx1 -> n36amry	Aluminum chlorohydrate 25145 mg Can [Secret Outlast Protecting Dry]


### PR DESCRIPTION
Finding the lack of differentiation of different sizes of enoxaparin were due to errors with processing the description:
-Solving issue where the description wasn't properly regexed due to a lack of a leading zero for a float value.
-Improving QUMI classification beyond just enoxaparin for all other drugs affected by this bug.